### PR TITLE
feat: genesis hash helpers

### DIFF
--- a/.changeset/fifty-ants-grow.md
+++ b/.changeset/fifty-ants-grow.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added genesis hash constant and to moniker function

--- a/packages/gill/src/__tests__/utils.ts
+++ b/packages/gill/src/__tests__/utils.ts
@@ -1,0 +1,23 @@
+import { GENESIS_HASH, getMonikerFromGenesisHash } from "../core";
+
+describe("getMonikerFromGenesisHash", () => {
+  it("should return 'mainnet' for mainnet genesis hash", () => {
+    const result = getMonikerFromGenesisHash(GENESIS_HASH.mainnet);
+    expect(result).toBe("mainnet");
+  });
+
+  it("should return 'devnet' for devnet genesis hash", () => {
+    const result = getMonikerFromGenesisHash(GENESIS_HASH.devnet);
+    expect(result).toBe("devnet");
+  });
+
+  it("should return 'testnet' for testnet genesis hash", () => {
+    const result = getMonikerFromGenesisHash(GENESIS_HASH.testnet);
+    expect(result).toBe("testnet");
+  });
+
+  it("should return 'unknown' for unrecognized hash", () => {
+    const result = getMonikerFromGenesisHash("unknown-hash-value");
+    expect(result).toBe("unknown");
+  });
+});

--- a/packages/gill/src/core/const.ts
+++ b/packages/gill/src/core/const.ts
@@ -1,2 +1,11 @@
-/** 1 billion lamports SOL */
+/** 1 billion lamports per SOL */
 export const LAMPORTS_PER_SOL = 1_000_000_000;
+
+/**
+ * Genesis hash for Solana network clusters
+ */
+export const GENESIS_HASH = {
+  mainnet: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+  testnet: "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY",
+};

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -1,5 +1,6 @@
 export { debug, isDebugEnabled } from "./debug";
 export * from "./const";
+export * from "./utils";
 export * from "./rpc";
 export * from "./explorer";
 export * from "./transactions";

--- a/packages/gill/src/core/utils.ts
+++ b/packages/gill/src/core/utils.ts
@@ -1,0 +1,20 @@
+import type { SolanaClusterMoniker } from "../types";
+import { GENESIS_HASH } from "./const";
+
+/**
+ * Determine the Solana moniker from its genesis hash
+ *
+ * If the hash is NOT known, returns `unknown`
+ */
+export function getMonikerFromGenesisHash(hash: string): SolanaClusterMoniker | "unknown" {
+  switch (hash) {
+    case GENESIS_HASH.mainnet:
+      return "mainnet";
+    case GENESIS_HASH.devnet:
+      return "devnet";
+    case GENESIS_HASH.testnet:
+      return "testnet";
+    default:
+      return "unknown";
+  }
+}


### PR DESCRIPTION
### Summary of Changes

- added `GENESIS_HASH` constant with primary cluster hashes
- added `getMonikerFromGenesisHash` function