### PR TITLE
`getExplorerLink` for base url

### DIFF
--- a/.changeset/nasty-dots-kiss.md
+++ b/.changeset/nasty-dots-kiss.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+allow `getExplorerLink` to return the base transaction url for each cluster

--- a/packages/gill/src/__tests__/explorer.ts
+++ b/packages/gill/src/__tests__/explorer.ts
@@ -4,6 +4,49 @@ import { FullySignedTransaction, getSignatureFromTransaction } from "@solana/tra
 import { getExplorerLink } from "../core";
 
 describe("getExplorerLink", () => {
+  test("getExplorerLink returns the base explorer url", () => {
+    const link = getExplorerLink();
+    assert.equal(link, "https://explorer.solana.com/");
+  });
+
+  test("getExplorerLink returns the base explorer url for mainnet", () => {
+    const link = getExplorerLink({
+      cluster: "mainnet",
+    });
+    assert.equal(link, "https://explorer.solana.com/");
+  });
+
+  test("getExplorerLink returns the base explorer url for mainnet-beta", () => {
+    const link = getExplorerLink({
+      cluster: "mainnet-beta",
+    });
+    assert.equal(link, "https://explorer.solana.com/");
+  });
+
+  test("getExplorerLink returns the base explorer url for devnet", () => {
+    const link = getExplorerLink({
+      cluster: "devnet",
+    });
+    assert.equal(link, "https://explorer.solana.com/?cluster=devnet");
+  });
+
+  test("getExplorerLink returns the base explorer url for testnet", () => {
+    const link = getExplorerLink({
+      cluster: "testnet",
+    });
+    assert.equal(link, "https://explorer.solana.com/?cluster=testnet");
+  });
+
+  test("getExplorerLink returns the base explorer url for localnet", () => {
+    const link = getExplorerLink({
+      cluster: "localnet",
+    });
+    assert.equal(
+      link,
+      "https://explorer.solana.com/?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899",
+    );
+  });
+
   test("getExplorerLink works for a block on mainnet when no network is supplied", () => {
     const link = getExplorerLink({
       block: "242233124",

--- a/packages/gill/src/core/explorer.ts
+++ b/packages/gill/src/core/explorer.ts
@@ -3,21 +3,21 @@ import { GetExplorerLinkArgs } from "../types";
 /**
  * Craft a Solana Explorer link on any cluster
  */
-export function getExplorerLink(props: GetExplorerLinkArgs): string {
+export function getExplorerLink(props: GetExplorerLinkArgs = {}): string {
   let url: URL | null = null;
 
   // default to mainnet / mainnet-beta
   if (!props.cluster || props.cluster == "mainnet") props.cluster = "mainnet-beta";
 
-  if ("address" in props) {
-    url = new URL(`https://explorer.solana.com/address/${props.address}`);
-  } else if ("transaction" in props) {
-    url = new URL(`https://explorer.solana.com/tx/${props.transaction}`);
-  } else if ("block" in props) {
-    url = new URL(`https://explorer.solana.com/block/${props.block}`);
-  }
+  url = new URL("https://explorer.solana.com");
 
-  if (!url) throw new Error("Invalid Solana Explorer URL created");
+  if ("address" in props) {
+    url.pathname = `/address/${props.address}`;
+  } else if ("transaction" in props) {
+    url.pathname = `/tx/${props.transaction}`;
+  } else if ("block" in props) {
+    url.pathname = `/block/${props.block}`;
+  }
 
   if (props.cluster !== "mainnet-beta") {
     if (props.cluster === "localnet") {

--- a/packages/gill/src/types/explorer.ts
+++ b/packages/gill/src/types/explorer.ts
@@ -15,4 +15,4 @@ type ExplorerLinkBlock = {
  */
 export type GetExplorerLinkArgs = {
   cluster?: SolanaClusterMoniker | "mainnet-beta";
-} & (ExplorerLinkAccount | ExplorerLinkTransaction | ExplorerLinkBlock);
+} & (ExplorerLinkAccount | ExplorerLinkTransaction | ExplorerLinkBlock | {});


### PR DESCRIPTION
### Problem

the `getExplorerLink` does not allow people to get a base explorer url

### Summary of Changes

- allow output a cluster specific base urls
- added tests for this new output