### PR TITLE
refactor: type and name

### DIFF
--- a/.changeset/big-mugs-push.md
+++ b/.changeset/big-mugs-push.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+refactor common type and use `feePayer` vs `payer` for consistency

--- a/examples/esrun/src/tokens.ts
+++ b/examples/esrun/src/tokens.ts
@@ -62,8 +62,8 @@ console.log("latestBlockhash:", latestBlockhash);
 const createTokenTx = await buildCreateTokenTransaction({
   mint,
   latestBlockhash,
-  payer: signer,
-  // mintAuthority, // default=same as the `payer`
+  feePayer: signer,
+  // mintAuthority, // default=same as the `feePayer`
   metadata: {
     isMutable: true, // if the `updateAuthority` can change this metadata in the future
     name: "Only Possible On Solana",
@@ -115,7 +115,7 @@ const destination = address("nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c");
  * - ensure the `mintAuthority` is the correct signer in order to actually mint new tokens
  */
 const mintTokensTx = await buildMintTokensTransaction({
-  payer: signer,
+  feePayer: signer,
   latestBlockhash,
   mint,
   mintAuthority: signer,

--- a/packages/gill/src/__tests__/create-token-instructions.ts
+++ b/packages/gill/src/__tests__/create-token-instructions.ts
@@ -122,7 +122,7 @@ describe("getCreateTokenInstructions", () => {
 
   it("should create basic token instructions with default values", () => {
     const args: GetCreateTokenInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint,
       metadataAddress: mockMetadataAddress,
       metadata,
@@ -174,7 +174,7 @@ describe("getCreateTokenInstructions", () => {
 
   it("should throw error for unsupported token program", () => {
     const args: GetCreateTokenInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint,
       metadataAddress: mockMetadataAddress,
       metadata,
@@ -189,7 +189,7 @@ describe("getCreateTokenInstructions", () => {
   describe("should use original token program", () => {
     it("should use original token program when specified", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMetadataAddress,
         tokenProgram: TOKEN_PROGRAM_ADDRESS,
@@ -214,7 +214,7 @@ describe("getCreateTokenInstructions", () => {
 
     it("should use custom decimals when provided", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         metadataAddress: mockMetadataAddress,
         mint: mockMint,
         decimals: 6,
@@ -233,7 +233,7 @@ describe("getCreateTokenInstructions", () => {
 
     it("should use custom mint and freeze authorities when provided", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMetadataAddress,
         metadata,
@@ -260,7 +260,7 @@ describe("getCreateTokenInstructions", () => {
       };
 
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMetadataAddress,
         metadata,
@@ -297,7 +297,7 @@ describe("getCreateTokenInstructions", () => {
       const customUpdateAuthority = { address: "customUpdateAuth" } as KeyPairSigner;
 
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMetadataAddress,
         updateAuthority: customUpdateAuthority,
@@ -317,7 +317,7 @@ describe("getCreateTokenInstructions", () => {
   describe("should use token22 program", () => {
     it("should use Token-2022 program when specified", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMint.address,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
@@ -342,7 +342,7 @@ describe("getCreateTokenInstructions", () => {
 
     it("should use custom decimals when provided", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMint.address,
         decimals: 6,
@@ -362,7 +362,7 @@ describe("getCreateTokenInstructions", () => {
 
     it("should use custom mint and freeze authorities when provided", () => {
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMint.address,
         metadata,
@@ -390,7 +390,7 @@ describe("getCreateTokenInstructions", () => {
       };
 
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMint.address,
         metadata,
@@ -435,7 +435,7 @@ describe("getCreateTokenInstructions", () => {
       const customUpdateAuthority = { address: "customUpdateAuth" } as KeyPairSigner;
 
       const args: GetCreateTokenInstructionsArgs = {
-        payer: mockPayer,
+        feePayer: mockPayer,
         mint: mockMint,
         metadataAddress: mockMint.address,
         updateAuthority: customUpdateAuthority,

--- a/packages/gill/src/__tests__/mint-tokens-instructions.ts
+++ b/packages/gill/src/__tests__/mint-tokens-instructions.ts
@@ -45,7 +45,7 @@ describe("getMintTokensInstructions", () => {
 
   it("should create instructions with default token program", () => {
     const args: GetMintTokensInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint.address,
       mintAuthority: mockMintAuthority,
       destination: mockDestination.address,
@@ -80,7 +80,7 @@ describe("getMintTokensInstructions", () => {
 
   it("should create instructions with Token-2022 program", () => {
     const args: GetMintTokensInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint.address,
       mintAuthority: mockMintAuthority,
       destination: mockDestination.address,
@@ -103,7 +103,7 @@ describe("getMintTokensInstructions", () => {
 
   it("should accept Address type for mint, mintAuthority, and destination", () => {
     const args: GetMintTokensInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: "mintAddress" as Address,
       mintAuthority: "mintAuthorityAddress" as Address,
       destination: "ownerAddress" as Address,
@@ -138,7 +138,7 @@ describe("getMintTokensInstructions", () => {
 
   it("should accept number type for amount", () => {
     const args: GetMintTokensInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint.address,
       mintAuthority: mockMintAuthority,
       destination: mockDestination.address,
@@ -164,7 +164,7 @@ describe("getMintTokensInstructions", () => {
 
   it("should throw error for unsupported token program", () => {
     const args: GetMintTokensInstructionsArgs = {
-      payer: mockPayer,
+      feePayer: mockPayer,
       mint: mockMint.address,
       mintAuthority: mockMintAuthority,
       destination: mockDestination.address,

--- a/packages/gill/src/__typetests__/create-token-transaction.ts
+++ b/packages/gill/src/__typetests__/create-token-transaction.ts
@@ -19,20 +19,20 @@ async () => {
   // Legacy transaction
   {
     (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       mint,
       metadata,
     })) satisfies BaseTransactionMessage<"legacy">;
 
     (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       metadata,
     })) satisfies BaseTransactionMessage<"legacy">;
 
     const txNotSignable = (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       metadata,
@@ -43,7 +43,7 @@ async () => {
     signTransactionMessageWithSigners(txNotSignable);
 
     const txSignable = (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       metadata,
@@ -57,14 +57,14 @@ async () => {
   // Version 0 transaction
   {
     (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       metadata,
     })) satisfies BaseTransactionMessage<0>;
 
     const txNotSignable = (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       metadata,
@@ -75,7 +75,7 @@ async () => {
     signTransactionMessageWithSigners(txNotSignable);
 
     const txSignable = (await buildCreateTokenTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       metadata,

--- a/packages/gill/src/__typetests__/mint-tokens-transaction.ts
+++ b/packages/gill/src/__typetests__/mint-tokens-transaction.ts
@@ -23,7 +23,7 @@ async () => {
   // Legacy transaction
   {
     (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       mint,
       destination,
       amount: 0,
@@ -32,7 +32,7 @@ async () => {
     })) satisfies BaseTransactionMessage<"legacy">;
 
     (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       destination,
@@ -42,7 +42,7 @@ async () => {
     })) satisfies BaseTransactionMessage<"legacy">;
 
     const txNotSignable = (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       destination,
@@ -56,7 +56,7 @@ async () => {
     signTransactionMessageWithSigners(txNotSignable);
 
     const txSignable = (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: "legacy",
       mint,
       destination,
@@ -73,7 +73,7 @@ async () => {
   // Version 0 transaction
   {
     (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       destination,
@@ -83,7 +83,7 @@ async () => {
     })) satisfies BaseTransactionMessage<0>;
 
     const txNotSignable = (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       destination,
@@ -97,7 +97,7 @@ async () => {
     signTransactionMessageWithSigners(txNotSignable);
 
     const txSignable = (await buildMintTokensTransaction({
-      payer: signer,
+      feePayer: signer,
       version: 0,
       mint,
       destination,

--- a/packages/gill/src/programs/token/instructions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/instructions/mint-tokens.ts
@@ -8,12 +8,9 @@ import {
   getCreateAssociatedTokenIdempotentInstruction,
 } from "@solana-program/token-2022";
 import { checkedAddress } from "../../../core";
+import type { TokenInstructionBase } from "./types";
 
-export type GetMintTokensInstructionsArgs = {
-  /** Signer that will pay for the rent storage deposit fee */
-  payer: KeyPairSigner;
-  /** Token mint to issue the tokens */
-  mint: KeyPairSigner | Address;
+export type GetMintTokensInstructionsArgs = TokenInstructionBase<KeyPairSigner | Address> & {
   /**
    * The authority address capable of authorizing minting of new tokens.
    *
@@ -36,13 +33,6 @@ export type GetMintTokensInstructionsArgs = {
   ata: Address;
   /** Amount of tokens to mint to the `owner` via their `ata` */
   amount: bigint | number;
-  /**
-   * Token program used to create the token's `mint`
-   *
-   * - (default) {@link TOKEN_PROGRAM_ADDRESS} - the original SPL Token Program
-   * - {@link TOKEN_2022_PROGRAM_ADDRESS} - the SPL Token Extensions Program (aka Token22)
-   **/
-  tokenProgram?: Address;
 };
 
 /**
@@ -57,7 +47,7 @@ export type GetMintTokensInstructionsArgs = {
  *
  * const instructions = getMintTokensInstructions({
  *   mint,
- *   payer: signer,
+ *   feePayer: signer,
  *   mintAuthority: signer,
  *   amount: 1000, // note: be sure to consider the mint's `decimals` value
  *   // if decimals=2 => this will mint 10.00 tokens
@@ -80,7 +70,7 @@ export function getMintTokensInstructions(args: GetMintTokensInstructionsArgs): 
       owner: checkedAddress(args.destination),
       mint: args.mint,
       ata: args.ata,
-      payer: args.payer,
+      payer: args.feePayer,
       tokenProgram: args.tokenProgram,
     }),
     getMintToInstruction(

--- a/packages/gill/src/programs/token/instructions/types.ts
+++ b/packages/gill/src/programs/token/instructions/types.ts
@@ -1,0 +1,18 @@
+import type { Address } from "@solana/addresses";
+import type { KeyPairSigner } from "@solana/signers";
+import type { TOKEN_PROGRAM_ADDRESS } from "../addresses";
+import type { TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
+
+export type TokenInstructionBase<TMint = KeyPairSigner | Address> = {
+  /** Signer that will pay for the rent storage deposit fee and transaction fees */
+  feePayer: KeyPairSigner;
+  /** Token mint to issue the tokens */
+  mint: TMint;
+  /**
+   * Token program used to create the token's `mint`
+   *
+   * - (default) {@link TOKEN_PROGRAM_ADDRESS} - the original SPL Token Program
+   * - {@link TOKEN_2022_PROGRAM_ADDRESS} - the SPL Token Extensions Program (aka Token22)
+   **/
+  tokenProgram?: Address;
+};

--- a/packages/gill/src/programs/token/transactions/create-token.ts
+++ b/packages/gill/src/programs/token/transactions/create-token.ts
@@ -48,7 +48,7 @@ type GetCreateTokenTransactionInput = Simplify<
  * const mint = await generateKeyPairSigner();
  *
  * const transaction = await buildCreateTokenTransaction({
- *   payer: signer,
+ *   feePayer: signer,
  *   latestBlockhash,
  *   mint,
  *   metadata: {
@@ -111,8 +111,8 @@ export async function buildCreateTokenTransaction<
   }
 
   return createTransaction(
-    (({ payer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer: payer,
+    (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
+      feePayer,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,
@@ -124,12 +124,12 @@ export async function buildCreateTokenTransaction<
           freezeAuthority,
           updateAuthority,
           metadata,
-          payer,
+          feePayer,
           tokenProgram,
           mint,
         }: typeof args) => ({
           mint: mint as KeyPairSigner,
-          payer,
+          feePayer,
           metadataAddress,
           metadata,
           decimals,

--- a/packages/gill/src/programs/token/transactions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/transactions/mint-tokens.ts
@@ -52,7 +52,7 @@ type GetCreateTokenTransactionInput = Simplify<
  * // or mint can be a keypair from a freshly created token
  *
  * const transaction = await buildMintTokensTransaction({
- *   payer: signer,
+ *   feePayer: signer,
  *   latestBlockhash,
  *   mint,
  *   mintAuthority: signer,
@@ -120,16 +120,24 @@ export async function buildMintTokensTransaction<
   }
 
   return createTransaction(
-    (({ payer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer: payer,
+    (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
+      feePayer,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,
       latestBlockhash,
       instructions: getMintTokensInstructions(
-        (({ tokenProgram, payer, mint, ata, mintAuthority, amount, destination }: typeof args) => ({
+        (({
           tokenProgram,
-          payer,
+          feePayer,
+          mint,
+          ata,
+          mintAuthority,
+          amount,
+          destination,
+        }: typeof args) => ({
+          tokenProgram,
+          feePayer,
           mint,
           mintAuthority,
           ata: ata as Address,


### PR DESCRIPTION
### Summary of Changes

- refactor common type info for token things
- renamed `payer` attribute to `feePayer` to keep consistent with transactions