### PR TITLE
fix: create client port

### DIFF
--- a/.changeset/chilled-hornets-sniff.md
+++ b/.changeset/chilled-hornets-sniff.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+fix createSolanaClient to accept port numbers and set the localnet port

--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -59,10 +59,20 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
     throw new Error("Unsupported protocol. Only HTTP and HTTPS are supported");
   }
 
+  if (rpcConfig?.port) {
+    urlOrMoniker.port = rpcConfig.port.toString();
+  }
+
   const rpc = createSolanaRpc<TCluster>(urlOrMoniker.toString() as TCluster, rpcConfig);
 
   if (urlOrMoniker.protocol.endsWith("s")) urlOrMoniker.protocol = "wss";
   else urlOrMoniker.protocol = "ws";
+
+  if (rpcSubscriptionsConfig?.port) {
+    urlOrMoniker.port = rpcSubscriptionsConfig.port.toString();
+  } else if (urlOrMoniker.hostname == "localhost" || urlOrMoniker.hostname.startsWith("127")) {
+    urlOrMoniker.port = "8900";
+  }
 
   const rpcSubscriptions = createSolanaRpcSubscriptions<TCluster>(
     urlOrMoniker.toString() as TCluster,

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -27,9 +27,9 @@ export type CreateSolanaClientArgs<
   /** Full RPC URL (for a private RPC endpoint) or the Solana moniker (for a public RPC endpoint) */
   urlOrMoniker: SolanaClusterMoniker | TClusterUrl | URL | ModifiedClusterUrl;
   /** Configuration used to create the `rpc` client */
-  rpcConfig?: Parameters<typeof createSolanaRpc>[1];
+  rpcConfig?: Parameters<typeof createSolanaRpc>[1] & { port?: number };
   /** Configuration used to create the `rpcSubscriptions` client */
-  rpcSubscriptionsConfig?: Parameters<typeof createSolanaRpcSubscriptions>[1];
+  rpcSubscriptionsConfig?: Parameters<typeof createSolanaRpcSubscriptions>[1] & { port?: number };
 };
 
 export type CreateSolanaClientResult<TClusterUrl extends ModifiedClusterUrl | string = string> = {


### PR DESCRIPTION
### Problem

The `createSolanaClient` function does not accept a port number for the rpc and rpcSubscriptions being created. And also does not change the port for localnet, which is different for the two connections.

### Summary of Changes

- accept port number in config inputs
- special handle the default localnet port number 