### PR TITLE
add base64 helpers

### DIFF
--- a/.changeset/spotty-buttons-doubt.md
+++ b/.changeset/spotty-buttons-doubt.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added transactionToBase64WithSigners to sign and base64 encode

--- a/packages/gill/src/__tests__/base64-transactions.ts
+++ b/packages/gill/src/__tests__/base64-transactions.ts
@@ -1,9 +1,7 @@
-import assert from "node:assert";
-
 import { blockhash } from "@solana/rpc-types";
-
 import { address } from "@solana/addresses";
-import { createTransaction, transactionToBase64 } from "../core";
+import { createKeyPairSignerFromPrivateKeyBytes, KeyPairSigner } from "@solana/signers";
+import { createTransaction, transactionToBase64, transactionToBase64WithSigners } from "../core";
 
 // initialize a sample transaction
 const tx = createTransaction({
@@ -16,11 +14,55 @@ const tx = createTransaction({
   },
 });
 
+// Corresponds to address `2xRiSnKRWfFwwtkBPewQ6E4QA2SK9kzypVukLh35hiS8`
+const MOCK_PRIVATE_KEY_BYTES = new Uint8Array([
+  0xeb, 0xfa, 0x65, 0xeb, 0x93, 0xdc, 0x79, 0x15, 0x7a, 0xba, 0xde, 0xa2, 0xf7, 0x94, 0x37, 0x9d,
+  0xfc, 0x07, 0x1d, 0x68, 0x86, 0x87, 0x37, 0x6d, 0xc5, 0xd5, 0xa0, 0x54, 0x12, 0x1d, 0x34, 0x4a,
+]);
+
 describe("transactionToBase64", () => {
   test("can base64 encode an unsigned transaction", () => {
     const expected =
       "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAABC7YxPJkVXZH3qqq8Nq1nwYa5Pm6+M9ZeObND0CCtBLXjfKbGfbEEIU1AEH81ttgpyiNLO+xurYCsjdCVcfR4YQA=";
 
-    assert.equal(expected, transactionToBase64(tx));
+    const result = transactionToBase64(tx);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("transactionToBase64WithSigners", () => {
+  let mockSigner: KeyPairSigner;
+
+  beforeAll(async () => {
+    mockSigner = await createKeyPairSignerFromPrivateKeyBytes(MOCK_PRIVATE_KEY_BYTES);
+  });
+
+  test("can base64 encode a transaction without signers", async () => {
+    const expected =
+      "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAABC7YxPJkVXZH3qqq8Nq1nwYa5Pm6+M9ZeObND0CCtBLXjfKbGfbEEIU1AEH81ttgpyiNLO+xurYCsjdCVcfR4YQA=";
+
+    const result = await transactionToBase64WithSigners(tx);
+
+    expect(result).toBe(expected);
+  });
+
+  test("can base64 encode a transaction with signer", async () => {
+    const expected =
+      "Ace42d/o4XA3NGfL6hslysKyc8kB0ILDUT6diotxWdxP1cdt+oNWGztxEPb5t0F797swnV7NLCguh94nGqetQwABAAABHQ6Thk3MgV/D8oYYCRHQCj/SBt4xoclCh8tD8F/J8rXjfKbGfbEEIU1AEH81ttgpyiNLO+xurYCsjdCVcfR4YQA=";
+
+    const tx = createTransaction({
+      version: "legacy",
+      feePayer: mockSigner,
+      instructions: [],
+      latestBlockhash: {
+        blockhash: blockhash("GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z"),
+        lastValidBlockHeight: 0n,
+      },
+    });
+
+    const result = await transactionToBase64WithSigners(tx);
+
+    expect(result).toBe(expected);
   });
 });

--- a/packages/gill/src/core/base64-transactions.ts
+++ b/packages/gill/src/core/base64-transactions.ts
@@ -1,4 +1,5 @@
 import { pipe } from "@solana/functional";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import { CompilableTransactionMessage } from "@solana/transaction-messages";
 
 import {
@@ -9,14 +10,28 @@ import {
 } from "@solana/transactions";
 
 /**
- * Compile a Transaction to a base64 string
+ * Compile a transaction to a base64 string
+ *
+ * Note: This will NOT attempt to sign the transaction,
+ * so it will be missing `signatures` from any of the attached Signers
+ *
+ * See {@link transactionToBase64WithSignatures}
  */
 export function transactionToBase64(
   tx: CompilableTransactionMessage | Transaction,
 ): Base64EncodedWireTransaction {
-  if ("messageBytes" in tx) {
-    return pipe(tx, getBase64EncodedWireTransaction);
-  } else {
-    return pipe(tx, compileTransaction, getBase64EncodedWireTransaction);
-  }
+  if ("messageBytes" in tx) return pipe(tx, getBase64EncodedWireTransaction);
+  else return pipe(tx, compileTransaction, getBase64EncodedWireTransaction);
+}
+
+/**
+ * Compile a transaction to a base64 string and partially sign it with all attached Signers
+ *
+ * See {@link partiallySignTransactionMessageWithSigners}
+ */
+export async function transactionToBase64WithSigners(
+  tx: CompilableTransactionMessage | Transaction,
+): Promise<Base64EncodedWireTransaction> {
+  if ("messageBytes" in tx) return transactionToBase64(tx);
+  else return transactionToBase64(await partiallySignTransactionMessageWithSigners(tx));
 }

--- a/packages/gill/src/core/base64-transactions.ts
+++ b/packages/gill/src/core/base64-transactions.ts
@@ -1,11 +1,11 @@
 import { pipe } from "@solana/functional";
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
-import { CompilableTransactionMessage } from "@solana/transaction-messages";
+import type { CompilableTransactionMessage } from "@solana/transaction-messages";
 
 import {
-  Transaction,
+  type Transaction,
   compileTransaction,
-  Base64EncodedWireTransaction,
+  type Base64EncodedWireTransaction,
   getBase64EncodedWireTransaction,
 } from "@solana/transactions";
 

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -15,7 +15,7 @@ import type { GetLatestBlockhashApi, Rpc, SimulateTransactionApi } from "@solana
 import { isSetComputeLimitInstruction } from "../programs/compute-budget";
 import { getComputeUnitEstimateForTransactionMessageFactory } from "../kit";
 import { debug } from "./debug";
-import { transactionToBase64 } from "./base64-transactions";
+import { transactionToBase64WithSigners } from "./base64-transactions";
 
 type PrepareCompilableTransactionMessage =
   | CompilableTransactionMessage
@@ -121,7 +121,10 @@ export async function prepareTransaction<TMessage extends PrepareCompilableTrans
 
   assertIsTransactionMessageWithBlockhashLifetime(config.transaction);
 
-  debug(`Transaction as base64: ${transactionToBase64(config.transaction)}`, "debug");
+  debug(
+    `Transaction as base64: ${await transactionToBase64WithSigners(config.transaction)}`,
+    "debug",
+  );
 
   return config.transaction;
 }

--- a/packages/gill/src/kit/send-transaction-internal.ts
+++ b/packages/gill/src/kit/send-transaction-internal.ts
@@ -12,7 +12,7 @@ import {
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
-import { debug, getExplorerLink, transactionToBase64 } from '../core';
+import { debug, getExplorerLink } from '../core';
 
 interface SendAndConfirmDurableNonceTransactionConfig
     extends SendTransactionBaseConfig,
@@ -82,8 +82,8 @@ export async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
     ...sendTransactionConfig
 }: SendTransactionBaseConfig): Promise<Signature> {
     debug(`Sending transaction: ${getExplorerLink({transaction: getSignatureFromTransaction(transaction)})}`)
-    debug(`Transaction as base64: ${transactionToBase64(transaction)}`, "debug");
     const base64EncodedWireTransaction = getBase64EncodedWireTransaction(transaction);
+    debug(`Transaction as base64: ${base64EncodedWireTransaction}`, "debug");
     return await rpc
         .sendTransaction(base64EncodedWireTransaction, {
             ...getSendTransactionConfigWithAdjustedPreflightCommitment(commitment, sendTransactionConfig),


### PR DESCRIPTION
### Summary of Changes

- add helper functions to convert a transaction to a base64 string, including options to partially sign or not.
- updated the debug log for base64 transactions to partially sign since this is more useful for troubleshooting