### PR TITLE
fix: mint tokens program address

### DIFF
--- a/.changeset/orange-cooks-dance.md
+++ b/.changeset/orange-cooks-dance.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+fix create token instructions to correctly handle desired token program

--- a/packages/gill/src/__tests__/create-token-instructions.ts
+++ b/packages/gill/src/__tests__/create-token-instructions.ts
@@ -143,12 +143,17 @@ describe("getCreateTokenInstructions", () => {
       programAddress: TOKEN_PROGRAM_ADDRESS,
     });
 
-    expect(getInitializeMintInstruction).toHaveBeenCalledWith({
-      mint: mockMint.address,
-      decimals: 9,
-      mintAuthority: mockPayer.address,
-      freezeAuthority: null,
-    });
+    expect(getInitializeMintInstruction).toHaveBeenCalledWith(
+      {
+        mint: mockMint.address,
+        decimals: 9,
+        mintAuthority: mockPayer.address,
+        freezeAuthority: null,
+      },
+      {
+        programAddress: TOKEN_PROGRAM_ADDRESS,
+      },
+    );
 
     expect(getCreateMetadataAccountV3Instruction).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -209,6 +214,9 @@ describe("getCreateTokenInstructions", () => {
         expect.objectContaining({
           mint: mockMint.address,
         }),
+        {
+          programAddress: TOKEN_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -228,6 +236,9 @@ describe("getCreateTokenInstructions", () => {
           mint: mockMint.address,
           decimals: 6,
         }),
+        {
+          programAddress: TOKEN_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -248,6 +259,9 @@ describe("getCreateTokenInstructions", () => {
           mintAuthority: mockMintAuthority.address,
           freezeAuthority: mockFreezeAuthority.address,
         }),
+        {
+          programAddress: TOKEN_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -337,6 +351,9 @@ describe("getCreateTokenInstructions", () => {
         expect.objectContaining({
           mint: mockMint.address,
         }),
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -357,6 +374,9 @@ describe("getCreateTokenInstructions", () => {
           mint: mockMint.address,
           decimals: 6,
         }),
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -378,6 +398,9 @@ describe("getCreateTokenInstructions", () => {
           mintAuthority: mockMintAuthority.address,
           freezeAuthority: mockFreezeAuthority.address,
         }),
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        },
       );
     });
 
@@ -416,6 +439,9 @@ describe("getCreateTokenInstructions", () => {
           mint: mockMint.address,
           mintAuthority: mockPayer.address,
         }),
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        },
       );
 
       expect(getInitializeTokenMetadataInstruction).toHaveBeenCalledWith(

--- a/packages/gill/src/programs/token/instructions/create-token.ts
+++ b/packages/gill/src/programs/token/instructions/create-token.ts
@@ -129,12 +129,17 @@ export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs)
         metadataAddress: args.metadataAddress,
         mint: args.mint.address,
       }),
-      getInitializeMintInstruction({
-        mint: args.mint.address,
-        decimals: Number(args.decimals),
-        mintAuthority: args.mintAuthority.address,
-        freezeAuthority: args.freezeAuthority || null,
-      }),
+      getInitializeMintInstruction(
+        {
+          mint: args.mint.address,
+          decimals: Number(args.decimals),
+          mintAuthority: args.mintAuthority.address,
+          freezeAuthority: args.freezeAuthority || null,
+        },
+        {
+          programAddress: args.tokenProgram,
+        },
+      ),
       getInitializeTokenMetadataInstruction({
         metadata: args.mint.address,
         mint: args.mint.address,
@@ -158,12 +163,17 @@ export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs)
         space,
         programAddress: args.tokenProgram,
       }),
-      getInitializeMintInstruction({
-        mint: args.mint.address,
-        decimals: Number(args.decimals),
-        mintAuthority: args.mintAuthority.address,
-        freezeAuthority: args.freezeAuthority || null,
-      }),
+      getInitializeMintInstruction(
+        {
+          mint: args.mint.address,
+          decimals: Number(args.decimals),
+          mintAuthority: args.mintAuthority.address,
+          freezeAuthority: args.freezeAuthority || null,
+        },
+        {
+          programAddress: args.tokenProgram,
+        },
+      ),
       getCreateMetadataAccountV3Instruction({
         metadata: args.metadataAddress,
         mint: args.mint.address,


### PR DESCRIPTION
### Problem

the mint token transaction builder does not correctly accept the user supplied token program

### Summary of Changes

- add the token program address on the `getInitializeMintInstruction`
- added tests to cover the program address being set correctly

Fixes #45 