### PR TITLE
fix: localhost cluster

### DIFF
--- a/.changeset/green-owls-help.md
+++ b/.changeset/green-owls-help.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+add `localhost` support to explorer urls

--- a/packages/gill/src/core/explorer.ts
+++ b/packages/gill/src/core/explorer.ts
@@ -1,4 +1,4 @@
-import { GetExplorerLinkArgs } from "../types";
+import type { GetExplorerLinkArgs } from "../types";
 
 /**
  * Craft a Solana Explorer link on any cluster
@@ -20,7 +20,7 @@ export function getExplorerLink(props: GetExplorerLinkArgs = {}): string {
   }
 
   if (props.cluster !== "mainnet-beta") {
-    if (props.cluster === "localnet") {
+    if (props.cluster === "localnet" || props.cluster === "localhost") {
       // localnet technically isn't a cluster, so requires special handling
       url.searchParams.set("cluster", "custom");
       url.searchParams.set("customUrl", "http://localhost:8899");

--- a/packages/gill/src/types/explorer.ts
+++ b/packages/gill/src/types/explorer.ts
@@ -1,4 +1,4 @@
-import { SolanaClusterMoniker } from "./rpc";
+import type { SolanaClusterMoniker } from "./rpc";
 
 type ExplorerLinkAccount = {
   address: string;
@@ -14,5 +14,5 @@ type ExplorerLinkBlock = {
  * @param cluster - Default: `mainnet`
  */
 export type GetExplorerLinkArgs = {
-  cluster?: SolanaClusterMoniker | "mainnet-beta";
+  cluster?: SolanaClusterMoniker | "mainnet-beta" | "localhost";
 } & (ExplorerLinkAccount | ExplorerLinkTransaction | ExplorerLinkBlock | {});


### PR DESCRIPTION
### Summary of Changes

added `localhost` cluster support (instead of just `localnet`) for getExplorerLink