### PR TITLE
feat: sendAndConfirmTransaction handle signing

### DIFF
--- a/.changeset/nervous-rivers-move.md
+++ b/.changeset/nervous-rivers-move.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+allow `sendAndConfirmTransaction` to also handle signing

--- a/packages/gill/src/kit/send-and-confirm-transaction.ts
+++ b/packages/gill/src/kit/send-and-confirm-transaction.ts
@@ -6,7 +6,7 @@ import {
     createRecentSignatureConfirmationPromiseFactory,
     waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
-import { type FullySignedTransaction, type TransactionWithBlockhashLifetime } from '@solana/transactions';
+import type { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
 
 import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
 import type { CompilableTransactionMessage } from '@solana/transaction-messages';

--- a/packages/gill/src/kit/send-and-confirm-transaction.ts
+++ b/packages/gill/src/kit/send-and-confirm-transaction.ts
@@ -6,12 +6,14 @@ import {
     createRecentSignatureConfirmationPromiseFactory,
     waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
-import type { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
+import { type FullySignedTransaction, type TransactionWithBlockhashLifetime } from '@solana/transactions';
 
 import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
+import type { CompilableTransactionMessage } from '@solana/transaction-messages';
+import { signTransactionMessageWithSigners } from '@solana/signers';
 
 export type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
-    transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
+    transaction: (FullySignedTransaction & TransactionWithBlockhashLifetime) | CompilableTransactionMessage,
     config?: Omit<
         Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
@@ -65,6 +67,9 @@ export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'ma
     }
 
     return async function sendAndConfirmTransaction(transaction, config = { commitment: "confirmed" }) {
+        if ("messageBytes" in transaction == false){
+            transaction = await signTransactionMessageWithSigners(transaction) as Readonly<FullySignedTransaction & TransactionWithBlockhashLifetime>;
+        }
         return await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmRecentTransaction,


### PR DESCRIPTION
### Summary of Changes

allow `sendAndConfirmTransaction` to also handle signing

this way dev code no longer need to manually sign with `partiallySignTransactionMessageWithSigners` or `signTransactionMessageWithSigners` unless they want to