### PR TITLE
JSON.stringify on BigInt

### DIFF
--- a/.changeset/swift-fireants-sparkle.md
+++ b/.changeset/swift-fireants-sparkle.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+patch BigInt prototype to allow calling JSON.stringify

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -68,7 +68,9 @@
   "files": [
     "./dist/"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/bigint.ts"
+  ],
   "keywords": [
     "blockchain",
     "solana",

--- a/packages/gill/src/bigint.ts
+++ b/packages/gill/src/bigint.ts
@@ -1,0 +1,16 @@
+/**
+ * Patch BigInt to allow calling `JSON.stringify` on objects that use
+ */
+
+interface BigInt {
+  /** Convert a BigInt to string form when calling `JSON.stringify()` */
+  toJSON: () => string;
+}
+
+// @ts-ignore - Only add the toJSON method if it doesn't already exist
+if (BigInt.prototype.toJSON === undefined) {
+  // @ts-ignore - toJSON does not exist which is why we are patching it
+  BigInt.prototype.toJSON = function () {
+    return String(this);
+  };
+}

--- a/packages/gill/src/core/debug.ts
+++ b/packages/gill/src/core/debug.ts
@@ -12,7 +12,16 @@ const GILL_LOG_LEVELS: Record<LogLevel, number> = {
 };
 
 declare global {
-  var __GILL_DEBUG__: LogLevel | boolean | undefined;
+  /**
+   * Whether or not to enable debug mode. When enabled, default log level of `info`
+   */
+  var __GILL_DEBUG__: boolean | undefined;
+  /**
+   * Set the a desired level of logs to be output in the application
+   *
+   * - Default: `info`
+   * - Options: `debug` | `info` | `warn` | `error`
+   */
   var __GILL_DEBUG_LEVEL__: LogLevel | undefined;
 }
 

--- a/packages/gill/src/index.ts
+++ b/packages/gill/src/index.ts
@@ -1,3 +1,5 @@
+import "./bigint";
+
 export * from "@solana/accounts";
 export * from "@solana/addresses";
 export * from "@solana/codecs";


### PR DESCRIPTION
### Problem

The JavaScript BigInt does default allow calling JSON.stringify on it due to lacking the toJSON function

### Summary of Changes

- patch the BigInt prototype to allow calling JSON.stringify
- also updated the debug mode global variables to include ts doc comments