### PR TITLE
Simulate transaction factory

### DIFF
--- a/.changeset/sour-kangaroos-peel.md
+++ b/.changeset/sour-kangaroos-peel.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added `simulateTransaction` and factory

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ yarn add gill
 - [Making Solana RPC calls](#making-solana-rpc-calls)
 - [Create a transaction](#create-a-transaction)
 - [Signing transactions](#signing-transactions)
+- [Simulating transactions](#simulating-transactions)
 - [Sending and confirming transaction](#sending-and-confirming-transactions)
 - [Get a transaction signature](#get-the-signature-from-a-signed-transaction)
 - [Get a Solana Explorer link](#get-a-solana-explorer-link-for-transactions-accounts-or-blocks)
@@ -265,10 +266,29 @@ const signedTransaction = await signTransactionMessageWithSigners(
 );
 ```
 
+### Simulating transactions
+
+To simulate a transaction on the blockchain, you can use the `simulateTransaction()` function
+initialized from `createSolanaClient()`.
+
+```typescript
+import { ... } from "gill";
+
+const { simulateTransaction } = createSolanaClient({
+  urlOrMoniker: "mainnet",
+});
+
+const transaction = createTransaction(...);
+
+const simulation = await simulateTransaction(transaction)
+```
+
+The transaction provided to `simulateTransaction()` can either be signed or not.
+
 ### Sending and confirming transactions
 
 To send and confirm a transaction to the blockchain, you can use the `sendAndConfirmTransaction`
-function initialized from `createSolanaClient`.
+function initialized from `createSolanaClient()`.
 
 ```typescript
 import { ... } from "gill";

--- a/examples/get-started/src/intro.ts
+++ b/examples/get-started/src/intro.ts
@@ -27,9 +27,10 @@ const cluster: SolanaClusterMoniker = "devnet";
  *
  * Note: `urlOrMoniker` can be either a Solana network moniker or a full URL of your RPC provider
  */
-const { rpc, sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: cluster,
-});
+const { rpc, sendAndConfirmTransaction, simulateTransaction } =
+  createSolanaClient({
+    urlOrMoniker: cluster,
+  });
 
 /**
  * Create a memo instruction to post a simple message onchain
@@ -59,6 +60,16 @@ let tx = createTransaction({
 });
 console.log("Transaction:");
 console.log(tx);
+
+/**
+ * Simulate the transaction
+ *
+ * Note: This is not required to be performed in your application,
+ * but can help catch errors during troubleshooting
+ */
+const simulation = await simulateTransaction(tx);
+console.log("transaction simulation:");
+console.log(simulation);
 
 /**
  * Sign the transaction with the provided `signer` when it was created

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -55,6 +55,7 @@ yarn add gill
 - [Making Solana RPC calls](#making-solana-rpc-calls)
 - [Create a transaction](#create-a-transaction)
 - [Signing transactions](#signing-transactions)
+- [Simulating transactions](#simulating-transactions)
 - [Sending and confirming transaction](#sending-and-confirming-transactions)
 - [Get a transaction signature](#get-the-signature-from-a-signed-transaction)
 - [Get a Solana Explorer link](#get-a-solana-explorer-link-for-transactions-accounts-or-blocks)
@@ -265,10 +266,29 @@ const signedTransaction = await signTransactionMessageWithSigners(
 );
 ```
 
+### Simulating transactions
+
+To simulate a transaction on the blockchain, you can use the `simulateTransaction()` function
+initialized from `createSolanaClient()`.
+
+```typescript
+import { ... } from "gill";
+
+const { simulateTransaction } = createSolanaClient({
+  urlOrMoniker: "mainnet",
+});
+
+const transaction = createTransaction(...);
+
+const simulation = await simulateTransaction(transaction)
+```
+
+The transaction provided to `simulateTransaction()` can either be signed or not.
+
 ### Sending and confirming transactions
 
 To send and confirm a transaction to the blockchain, you can use the `sendAndConfirmTransaction`
-function initialized from `createSolanaClient`.
+function initialized from `createSolanaClient()`.
 
 ```typescript
 import { ... } from "gill";

--- a/packages/gill/src/__typetests__/create-solana-client.ts
+++ b/packages/gill/src/__typetests__/create-solana-client.ts
@@ -19,7 +19,11 @@ import {
 {
   // Mainnet cluster typechecks when the providing the moniker
   {
-    const { rpc: mainnetRpc, rpcSubscriptions: mainnetRpcSubscriptions } = createSolanaClient({
+    const {
+      rpc: mainnetRpc,
+      rpcSubscriptions: mainnetRpcSubscriptions,
+      simulateTransaction,
+    } = createSolanaClient({
       urlOrMoniker: "mainnet",
     });
     mainnetRpc satisfies Rpc<SolanaRpcApiMainnet>;
@@ -30,6 +34,9 @@ import {
     mainnetRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a testnet RPC
     mainnetRpc satisfies RpcTestnet<SolanaRpcApi>;
+
+    // should have access to `simulateTransaction`
+    simulateTransaction;
 
     sendAndConfirmTransactionFactory({
       rpc: mainnetRpc,
@@ -43,7 +50,11 @@ import {
 
   // Devnet cluster typechecks when the providing the moniker
   {
-    const { rpc: devnetRpc, rpcSubscriptions: devnetRpcSubscriptions } = createSolanaClient({
+    const {
+      rpc: devnetRpc,
+      rpcSubscriptions: devnetRpcSubscriptions,
+      simulateTransaction,
+    } = createSolanaClient({
       urlOrMoniker: "devnet",
     });
     devnetRpc satisfies Rpc<SolanaRpcApi>;
@@ -53,6 +64,9 @@ import {
     devnetRpc satisfies RpcTestnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     devnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    // should have access to `simulateTransaction`
+    simulateTransaction;
 
     sendAndConfirmTransactionFactory({
       rpc: devnetRpc,
@@ -66,7 +80,11 @@ import {
 
   // Testnet cluster typechecks when the providing the moniker
   {
-    const { rpc: testnetRpc, rpcSubscriptions: testnetRpcSubscriptions } = createSolanaClient({
+    const {
+      rpc: testnetRpc,
+      rpcSubscriptions: testnetRpcSubscriptions,
+      simulateTransaction,
+    } = createSolanaClient({
       urlOrMoniker: "testnet",
     });
     testnetRpc satisfies Rpc<SolanaRpcApi>;
@@ -76,6 +94,9 @@ import {
     testnetRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     testnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    // should have access to `simulateTransaction`
+    simulateTransaction;
 
     sendAndConfirmTransactionFactory({
       rpc: testnetRpc,
@@ -89,7 +110,11 @@ import {
 
   // Localnet cluster typechecks when the providing the moniker
   {
-    const { rpc: localnetRpc, rpcSubscriptions: localnetRpcSubscriptions } = createSolanaClient({
+    const {
+      rpc: localnetRpc,
+      rpcSubscriptions: localnetRpcSubscriptions,
+      simulateTransaction,
+    } = createSolanaClient({
       urlOrMoniker: "localnet",
     });
     localnetRpc satisfies Rpc<SolanaRpcApi>;
@@ -101,6 +126,9 @@ import {
     //@ts-expect-error Should not be a mainnet RPC
     localnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
 
+    // should have access to `simulateTransaction`
+    simulateTransaction;
+
     sendAndConfirmTransactionFactory({
       rpc: localnetRpc,
       rpcSubscriptions: localnetRpcSubscriptions,
@@ -113,7 +141,11 @@ import {
 
   // Localnet cluster typechecks when the providing the moniker
   {
-    const { rpc: genericRpc, rpcSubscriptions: genericRpcSubscriptions } = createSolanaClient({
+    const {
+      rpc: genericRpc,
+      rpcSubscriptions: genericRpcSubscriptions,
+      simulateTransaction,
+    } = createSolanaClient({
       urlOrMoniker: "https://example-rpc.com",
     });
     genericRpc satisfies Rpc<SolanaRpcApi>;
@@ -124,6 +156,9 @@ import {
     genericRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     genericRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    // should have access to `simulateTransaction`
+    simulateTransaction;
 
     sendAndConfirmTransactionFactory({
       rpc: genericRpc,

--- a/packages/gill/src/__typetests__/simulate-transaction.ts
+++ b/packages/gill/src/__typetests__/simulate-transaction.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Rpc, RpcDevnet, RpcMainnet, RpcTestnet, SimulateTransactionApi } from "@solana/rpc";
+import { simulateTransactionFactory } from "../core/simulate-transaction";
+import { FullySignedTransaction, Transaction } from "@solana/transactions";
+import { CompilableTransactionMessage } from "@solana/transaction-messages";
+
+const rpc = null as unknown as Rpc<SimulateTransactionApi>;
+const rpcDevnet = null as unknown as RpcDevnet<SimulateTransactionApi>;
+const rpcTestnet = null as unknown as RpcTestnet<SimulateTransactionApi>;
+const rpcMainnet = null as unknown as RpcMainnet<SimulateTransactionApi>;
+
+const baseTransaction = null as unknown as Transaction;
+const compilableTransaction = null as unknown as CompilableTransactionMessage;
+const signedTransaction = null as unknown as FullySignedTransaction;
+
+// [DESCRIBE] simulateTransactionFactory
+{
+  {
+    // It typechecks when either RPC is generic.
+    simulateTransactionFactory({ rpc });
+    // It typechecks when the RPC clusters match.
+    simulateTransactionFactory({ rpc: rpcDevnet });
+    simulateTransactionFactory({ rpc: rpcTestnet });
+    simulateTransactionFactory({ rpc: rpcMainnet });
+  }
+  {
+    const simulateTransaction = simulateTransactionFactory({ rpc });
+
+    // It can accept a compilable transaction
+    simulateTransaction(compilableTransaction);
+    simulateTransaction(baseTransaction);
+
+    // It can accepted a signed transaction
+    simulateTransaction(signedTransaction);
+  }
+}

--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types/rpc";
 import { sendAndConfirmTransactionFactory } from "../kit";
 import { getPublicSolanaRpcUrl } from "./rpc";
+import { simulateTransactionFactory } from "./simulate-transaction";
 
 /**
  * Create a Solana `rpc` and `rpcSubscriptions` client
@@ -79,12 +80,12 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
     rpcSubscriptionsConfig,
   );
 
-  // @ts-ignore
-  const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
-
   return {
     rpc,
     rpcSubscriptions,
-    sendAndConfirmTransaction,
+    // @ts-ignore
+    sendAndConfirmTransaction: sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions }),
+    // @ts-ignore
+    simulateTransaction: simulateTransactionFactory({ rpc }),
   };
 }

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -10,3 +10,4 @@ export * from "./accounts";
 export * from "./keypairs";
 export * from "./base64-to-transaction";
 export * from "./base64-from-transaction";
+export * from "./simulate-transaction";

--- a/packages/gill/src/core/simulate-transaction.ts
+++ b/packages/gill/src/core/simulate-transaction.ts
@@ -40,9 +40,9 @@ export function simulateTransactionFactory<
     return rpc
       .simulateTransaction(getBase64EncodedWireTransaction(transaction), {
         replaceRecentBlockhash: true,
-        sigVerify: false,
         // innerInstructions: true,
         ...config,
+        sigVerify: false,
         encoding: "base64",
       })
       .send();

--- a/packages/gill/src/core/simulate-transaction.ts
+++ b/packages/gill/src/core/simulate-transaction.ts
@@ -1,0 +1,50 @@
+import type { Simplify } from "./../types/index";
+import type { Rpc, SimulateTransactionApi } from "@solana/rpc";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
+import { type CompilableTransactionMessage } from "@solana/transaction-messages";
+import { getBase64EncodedWireTransaction, type Transaction } from "@solana/transactions";
+
+export type SimulateTransactionFunction = (
+  transaction: Transaction | CompilableTransactionMessage,
+  config?: Simplify<
+    Omit<Parameters<SimulateTransactionApi["simulateTransaction"]>[1], "encoding" | "sigVerify">
+  >,
+) => Promise<ReturnType<SimulateTransactionApi["simulateTransaction"]>>;
+
+type SimulateTransactionFactoryConfig<TCluster> = {
+  rpc: Rpc<SimulateTransactionApi> & {
+    "~cluster"?: TCluster;
+  };
+};
+
+export function simulateTransactionFactory({
+  rpc,
+}: SimulateTransactionFactoryConfig<"devnet">): SimulateTransactionFunction;
+export function simulateTransactionFactory({
+  rpc,
+}: SimulateTransactionFactoryConfig<"testnet">): SimulateTransactionFunction;
+export function simulateTransactionFactory({
+  rpc,
+}: SimulateTransactionFactoryConfig<"mainnet">): SimulateTransactionFunction;
+export function simulateTransactionFactory({
+  rpc,
+}: SimulateTransactionFactoryConfig<"localnet">): SimulateTransactionFunction;
+export function simulateTransactionFactory<
+  TCluster extends "devnet" | "mainnet" | "testnet" | "localnet" | void = void,
+>({ rpc }: SimulateTransactionFactoryConfig<TCluster>): SimulateTransactionFunction {
+  return async function simulateTransaction(transaction, config) {
+    if ("messageBytes" in transaction == false) {
+      transaction = await partiallySignTransactionMessageWithSigners(transaction);
+    }
+
+    return rpc
+      .simulateTransaction(getBase64EncodedWireTransaction(transaction), {
+        replaceRecentBlockhash: true,
+        sigVerify: false,
+        // innerInstructions: true,
+        ...config,
+        encoding: "base64",
+      })
+      .send();
+  };
+}

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -10,7 +10,8 @@ import type {
   SolanaRpcSubscriptionsApi,
 } from "@solana/rpc-subscriptions";
 import type { DevnetUrl, MainnetUrl, TestnetUrl } from "@solana/rpc-types";
-import type { SendAndConfirmTransactionWithBlockhashLifetimeFunction } from "../kit";
+import type { SendAndConfirmTransactionWithBlockhashLifetimeFunction } from "../kit/send-and-confirm-transaction";
+import type { SimulateTransactionFunction } from "../core/simulate-transaction";
 
 /** Solana cluster moniker */
 export type SolanaClusterMoniker = "mainnet" | "devnet" | "testnet" | "localnet";
@@ -46,4 +47,8 @@ export type SolanaClient<TClusterUrl extends ModifiedClusterUrl | string = strin
    * Default commitment level: `confirmed`
    */
   sendAndConfirmTransaction: SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+  /**
+   * Simulate a transaction on the network
+   */
+  simulateTransaction: SimulateTransactionFunction;
 };


### PR DESCRIPTION
### Problem

simulating a transaction currently requires multiple steps and getting the correct info set. this can be simplified since it is such a common task

### Summary of Changes

- add a simulate transaction factory
- include `simulateTransaction` in `createSolanaClient`