### PR TITLE
accept localhost in `getPublicSolanaRpcUrl`

### DIFF
--- a/.changeset/brave-coins-dream.md
+++ b/.changeset/brave-coins-dream.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+accept 'localhost' in the public endpoint getter

--- a/packages/gill/src/__tests__/rpc.ts
+++ b/packages/gill/src/__tests__/rpc.ts
@@ -23,6 +23,10 @@ describe("getPublicSolanaRpcUrl", () => {
     const rpcUrl = getPublicSolanaRpcUrl("localnet");
     assert.equal(rpcUrl, "http://127.0.0.1:8899");
   });
+  test("getPublicSolanaRpcUrl returns localhost url", () => {
+    const rpcUrl = getPublicSolanaRpcUrl("localhost");
+    assert.equal(rpcUrl, "http://127.0.0.1:8899");
+  });
   test("getPublicSolanaRpcUrl show throw error on unsupported moniker", () => {
     // @ts-expect-error - `not-supported` is not a valid moniker
     assert.throws(() => getPublicSolanaRpcUrl("not-supported"), Error);

--- a/packages/gill/src/core/rpc.ts
+++ b/packages/gill/src/core/rpc.ts
@@ -11,7 +11,7 @@ export function localnet(putativeString: string): LocalnetUrl {
  * Note: These RPC URLs are rate limited and not suitable for production applications.
  */
 export function getPublicSolanaRpcUrl(
-  cluster: SolanaClusterMoniker | "mainnet-beta",
+  cluster: SolanaClusterMoniker | "mainnet-beta" | "localhost",
 ): ModifiedClusterUrl {
   switch (cluster) {
     case "devnet":
@@ -22,6 +22,7 @@ export function getPublicSolanaRpcUrl(
     case "mainnet":
       return "https://api.mainnet-beta.solana.com" as MainnetUrl;
     case "localnet":
+    case "localhost":
       return "http://127.0.0.1:8899" as LocalnetUrl;
     default:
       throw new Error("Invalid cluster moniker");


### PR DESCRIPTION
### Problem

`getPublicSolanaRpcUrl` does not accept `localhost` but it does accept `localnet` 

### Summary of Changes

added localhost to `getPublicSolanaRpcUrl`