### PR TITLE
Refactor lamportsPerSol to use scientific format

### DIFF
--- a/.changeset/warm-humans-bow.md
+++ b/.changeset/warm-humans-bow.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+Refactor `lamportsPerSol` to use scientific format

--- a/packages/gill/src/__tests__/utils.ts
+++ b/packages/gill/src/__tests__/utils.ts
@@ -1,4 +1,4 @@
-import { GENESIS_HASH, getMonikerFromGenesisHash } from "../core";
+import { GENESIS_HASH, getMonikerFromGenesisHash, lamportsToSol } from "../core";
 
 describe("getMonikerFromGenesisHash", () => {
   it("should return 'mainnet' for mainnet genesis hash", () => {
@@ -19,5 +19,33 @@ describe("getMonikerFromGenesisHash", () => {
   it("should return 'unknown' for unrecognized hash", () => {
     const result = getMonikerFromGenesisHash("unknown-hash-value");
     expect(result).toBe("unknown");
+  });
+});
+
+describe("lamportsToSol", () => {
+  it("should convert correctly to 1 SOL", () => {
+    const result = lamportsToSol(1_000_000_000);
+    expect(result).toBe("1");
+  });
+
+  it("should convert correctly to 0.5 SOL", () => {
+    const result = lamportsToSol(500_000_000);
+    expect(result).toBe("0.5");
+  });
+
+  it("should convert correctly to 0.000000001 SOL", () => {
+    const result = lamportsToSol(1);
+    expect(result).toBe("0.000000001");
+  });
+
+  it("should convert correctly to 0 SOL", () => {
+    const result = lamportsToSol(0);
+    expect(result).toBe("0");
+  });
+
+  it("should convert a BigInt correctly", () => {
+    // Max safe number value is 9_007_199_254_740_991
+    const result = lamportsToSol(10_000_000_333_333_333n);
+    expect(result).toBe("10,000,000.333333333");
   });
 });

--- a/packages/gill/src/core/utils.ts
+++ b/packages/gill/src/core/utils.ts
@@ -1,6 +1,7 @@
-import type { KeyPairSigner, Address } from "@solana/kit";
+import type { Address, KeyPairSigner } from "@solana/kit";
+
 import type { SolanaClusterMoniker } from "../types";
-import { GENESIS_HASH, LAMPORTS_PER_SOL } from "./const";
+import { GENESIS_HASH } from "./const";
 
 /**
  * Determine the Solana moniker from its genesis hash
@@ -20,7 +21,7 @@ export function getMonikerFromGenesisHash(hash: string): SolanaClusterMoniker | 
   }
 }
 
-export function checkedAddress(input: KeyPairSigner | Address): Address {
+export function checkedAddress(input: Address | KeyPairSigner): Address {
   return typeof input == "string" ? input : input.address;
 }
 
@@ -28,5 +29,6 @@ export function checkedAddress(input: KeyPairSigner | Address): Address {
  * Convert a lamport number to the human readable string of a SOL value
  */
 export function lamportsToSol(lamports: bigint | number): string {
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 9 }).format(Number(lamports) / LAMPORTS_PER_SOL);
+  // @ts-expect-error This format is valid
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 9 }).format(`${lamports}E-9`);
 }


### PR DESCRIPTION
### Problem

The current implementation of `lamportsToSol` can lose precision because of float division

### Summary of Changes

`lamportsPerSol` now uses the scientific number format. The JS number formatter supports using this, eg. `format('500E-2') === 5`

So instead of dividing by `LAMPORTS_PER_SOL`, we just do `${lamports}E-9`. This works with a number or BigInt natively. 

This eliminates the cast to number, and the division, both of which can lose precision. It also generalises to arbitrary decimals if you want to provide a similar helper for tokens later. 

I've also added tests so you can verify this works! 