### PR TITLE
fix: broken link to sdk repo

### DIFF
--- a/packages/gill/src/core/accounts.ts
+++ b/packages/gill/src/core/accounts.ts
@@ -5,7 +5,8 @@ export function getMinimumBalanceForRentExemption(space: bigint | number = 0) {
   /**
    * Default values for Rent calculations
    *
-   * Values taken from: https://github.com/anza-xyz/agave/blob/master/sdk/rent/src/lib.rs#L93-L97
+   * Values taken from: https://github.com/anza-xyz/solana-sdk/blob/c07f692e41d757057c8700211a9300cdcd6d33b1/rent/src/lib.rs#L93-L97
+   * 
    */
   const RENT = {
     /**


### PR DESCRIPTION
### Problem
Broken link. The sdk repo has been moved out of agave repo


### Summary of Changes
update link to point to new sdk repo