### PR TITLE
changeset limitations for peer deps

### DIFF
--- a/.changeset/long-dryers-exercise.md
+++ b/.changeset/long-dryers-exercise.md
@@ -1,0 +1,5 @@
+---
+"gill-react": patch
+---
+
+refactor peer dep due to changeset limitations

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,8 +64,10 @@
     "@types/react-test-renderer": "^18",
     "react": "^18"
   },
+  "dependencies": {
+    "gill": "workspace:*"
+  },
   "peerDependencies": {
-    "gill": "workspace:*",
     "@tanstack/react-query": "^5.61.4",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
### Problem

changeset peer dep updates results in major version bumps, including if using a workspace pacakge....
see [here](https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies)

### Summary of Changes

change `gill` to be a dep of `gill-react` instead of peer dep