### PR TITLE
fix bug with https into ws

### DIFF
--- a/.changeset/quick-pandas-bow.md
+++ b/.changeset/quick-pandas-bow.md
@@ -1,5 +1,5 @@
 ---
-"gill": minor
+"gill": patch
 ---
 
 Fix bug with converting https -> wss

--- a/.changeset/quick-pandas-bow.md
+++ b/.changeset/quick-pandas-bow.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+Fix bug with converting https -> wss

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gill",
   "license": "MIT",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "a modern javascript/typescript client library for interacting with the Solana blockchain",
   "scripts": {
     "clean": "rimraf dist build node_modules .turbo",

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gill",
   "license": "MIT",
-  "version": "0.8.2",
+  "version": "0.8.1",
   "description": "a modern javascript/typescript client library for interacting with the Solana blockchain",
   "scripts": {
     "clean": "rimraf dist build node_modules .turbo",

--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -60,7 +60,7 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
 
   const rpc = createSolanaRpc<TCluster>(urlOrMoniker.toString() as TCluster, rpcConfig);
 
-  if (urlOrMoniker.protocol.endsWith("s")) urlOrMoniker.protocol = "wss";
+  if (urlOrMoniker.protocol == "https:") urlOrMoniker.protocol = "wss";
   else urlOrMoniker.protocol = "ws";
 
   if (rpcSubscriptionsConfig?.port) {

--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -60,8 +60,7 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
 
   const rpc = createSolanaRpc<TCluster>(urlOrMoniker.toString() as TCluster, rpcConfig);
 
-  if (urlOrMoniker.protocol == "https:") urlOrMoniker.protocol = "wss";
-  else urlOrMoniker.protocol = "ws";
+  urlOrMoniker.protocol = urlOrMoniker.protocol.replace('http', 'ws');
 
   if (rpcSubscriptionsConfig?.port) {
     urlOrMoniker.port = rpcSubscriptionsConfig.port.toString();


### PR DESCRIPTION
### Problem
There was a bug in converting `https` urls into `wss` urls. The nature of the bug can be found by running
```
const thing= new URL("https://engine.mirror.ad/rpc/ac7e6cd2-8cee-455c-9b29-20e9424402f0")
console.log(thing.protocol)
```
You will find the url.protocol is `https:`

The existing code runs a function `.endsWith("s")` which the string ends with `:` not `s`. This push fixes that.


### Summary of Changes
Fix the bug mentioned above


Fixes #
Fix the bug with converting https into wss