### PR TITLE
docs: clarify getting a signature after fee payer signs

### DIFF
--- a/.changeset/shy-lions-pretend.md
+++ b/.changeset/shy-lions-pretend.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+clarify the readme and examples on getting the signature from a singed transaction

--- a/README.md
+++ b/README.md
@@ -320,7 +320,8 @@ await sendAndConfirmTransaction(signedTransaction, {
 
 ### Get the signature from a signed transaction
 
-After you already have a partially or fully signed transaction, you can get the transaction signature as follows:
+After you have a transaction signed by the `feePayer` (either a partially or fully signed transaction), you can get the
+transaction signature as follows:
 
 ```typescript
 import { getSignatureFromTransaction } from "gill";
@@ -330,9 +331,9 @@ console.log(signature);
 // Example output: 4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg
 ```
 
-> Note: After a transaction has been signed by at least one Signer, it will have a transaction signature (aka
-> transaction id). This is due to Solana transaction ids are the first item in the transaction's `signatures` array.
-> Therefore, client applications can know the signature before it is even sent to the network for confirmation.
+> Note: After a transaction has been signed by the fee payer, it will have a transaction signature (aka transaction id).
+> This is due to Solana transaction ids are the first item in the transaction's `signatures` array. Therefore, client
+> applications can potentially know the signature before it is even sent to the network for confirmation.
 
 ### Get a Solana Explorer link for transactions, accounts, or blocks
 

--- a/examples/get-started/src/intro.ts
+++ b/examples/get-started/src/intro.ts
@@ -79,7 +79,7 @@ console.log("signedTransaction:");
 console.log(signedTransaction);
 
 /**
- * Get the transaction signature after it has been signed by at least one signer
+ * Get the transaction signature after it has been signed by the `feePayer`
  */
 let signature = getSignatureFromTransaction(signedTransaction);
 

--- a/examples/get-started/src/tokens.ts
+++ b/examples/get-started/src/tokens.ts
@@ -104,7 +104,7 @@ console.log("signedTransaction:");
 console.log(signedTransaction);
 
 /**
- * Get the transaction signature after it has been signed by at least one signer
+ * Get the transaction signature after it has been signed by the `feePayer`
  */
 let signature = getSignatureFromTransaction(signedTransaction);
 

--- a/examples/tokens/src/1.intro.ts
+++ b/examples/tokens/src/1.intro.ts
@@ -68,7 +68,7 @@ console.log("signedTransaction:");
 console.log(signedTransaction);
 
 /**
- * Get the transaction signature after it has been signed by at least one signer
+ * Get the transaction signature after it has been signed by the `feePayer`
  */
 let signature = getSignatureFromTransaction(signedTransaction);
 

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -320,7 +320,8 @@ await sendAndConfirmTransaction(signedTransaction, {
 
 ### Get the signature from a signed transaction
 
-After you already have a partially or fully signed transaction, you can get the transaction signature as follows:
+After you have a transaction signed by the `feePayer` (either a partially or fully signed transaction), you can get the
+transaction signature as follows:
 
 ```typescript
 import { getSignatureFromTransaction } from "gill";
@@ -330,9 +331,9 @@ console.log(signature);
 // Example output: 4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg
 ```
 
-> Note: After a transaction has been signed by at least one Signer, it will have a transaction signature (aka
-> transaction id). This is due to Solana transaction ids are the first item in the transaction's `signatures` array.
-> Therefore, client applications can know the signature before it is even sent to the network for confirmation.
+> Note: After a transaction has been signed by the fee payer, it will have a transaction signature (aka transaction id).
+> This is due to Solana transaction ids are the first item in the transaction's `signatures` array. Therefore, client
+> applications can potentially know the signature before it is even sent to the network for confirmation.
 
 ### Get a Solana Explorer link for transactions, accounts, or blocks
 


### PR DESCRIPTION
### Problem

#88

### Summary of Changes

clarify readme and comments in examples around getting a signature only after the fee payer has signed, not just any signer

Fixes #88