### PR TITLE
[feat] useAccount decoder

### DIFF
--- a/.changeset/eleven-seas-love.md
+++ b/.changeset/eleven-seas-love.md
@@ -1,0 +1,5 @@
+---
+"gill-react": minor
+---
+
+add decoder support `useAccount` hook

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -243,6 +243,33 @@ export function PageClient() {
 }
 ```
 
+You can also provide a `Decoder` for known account data structure in order to decode the `data` byte array into a typed
+object:
+
+```tsx
+"use client";
+
+import { useAccount } from "gill-react";
+import { getMintDecoder } from "gill/programs/token";
+
+export function PageClient() {
+  const { account, isLoading, isError, error } = useAccount({
+    // USDC mint account (on Solana mainnet)
+    address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    decoder: getMintDecoder(),
+  });
+
+  // if (isLoading) { return ... }
+  // if (isError) { return ... }
+
+  return (
+    <div className="">
+      <pre>account: {JSON.stringify(account, null, "\t")}</pre>
+    </div>
+  );
+}
+```
+
 ### Get signature statuses
 
 Get the statuses of signatures using the Solana RPC method of

--- a/packages/react/src/__typeset__/account.ts
+++ b/packages/react/src/__typeset__/account.ts
@@ -1,16 +1,20 @@
 import { Account, Address } from "gill";
 import { useAccount } from "../hooks";
+import { getMetadataDecoder, Metadata } from "gill/programs";
 
 // [DESCRIBE] useAccount
 {
-  const address = null as unknown as Address;
+  const address = null as unknown as Address<"12345">;
 
+  // Should use default account data type
   {
     const { account } = useAccount({ address });
     // Should have `exists=true` declared
     account satisfies { exists: true };
     // Should be a Uint8Array for the data
     account satisfies Account<Uint8Array>;
+    // Should use the address type
+    account.address satisfies Address<"12345">;
 
     // @ts-expect-error - Should not allow no argument
     useAccount();
@@ -19,6 +23,7 @@ import { useAccount } from "../hooks";
     useAccount({});
   }
 
+  // Should accept `config` input
   {
     const { account } = useAccount({
       address,
@@ -28,5 +33,15 @@ import { useAccount } from "../hooks";
     account satisfies { exists: true };
     // Should be a Uint8Array for the data
     account satisfies Account<Uint8Array>;
+  }
+
+  // Should use the decoder type
+  {
+    const { account } = useAccount({
+      address,
+      decoder: getMetadataDecoder(),
+    });
+    // Should be a `Metadata` type for the data
+    account satisfies Account<Metadata>;
   }
 }

--- a/packages/react/src/hooks/account.ts
+++ b/packages/react/src/hooks/account.ts
@@ -9,7 +9,7 @@ import type { GillUseRpcHook } from "./types";
 
 type RpcConfig = Simplify<Parameters<typeof fetchEncodedAccount>>[2];
 
-type UseAccountResponse<TData extends Uint8Array | object = Uint8Array, TAddress extends string = string> = Account<
+type UseAccountResponse<TAddress extends string = string, TData extends Uint8Array | object = Uint8Array> = Account<
   TData,
   TAddress
 > & {
@@ -55,6 +55,6 @@ export function useAccount<
   });
   return {
     ...rest,
-    account: data as UseAccountResponse<TDecodedData, TAddress>,
+    account: data as UseAccountResponse<TAddress, TDecodedData>,
   };
 }


### PR DESCRIPTION
### Summary of Changes

added `decoder` field for the `useAccount` hook to more easily use any `Decoder` for an account