### PR TITLE
feat: accept abort signal

### DIFF
--- a/.changeset/selfish-dryers-burn.md
+++ b/.changeset/selfish-dryers-burn.md
@@ -1,0 +1,5 @@
+---
+"gill-react": patch
+---
+
+add support for AbortSignal on existing hooks

--- a/packages/react/src/hooks/balance.ts
+++ b/packages/react/src/hooks/balance.ts
@@ -24,6 +24,7 @@ type UseBalanceInput<TConfig extends RpcConfig = RpcConfig> = GillUseRpcHook<TCo
 export function useBalance<TConfig extends RpcConfig = RpcConfig>({
   options,
   config,
+  abortSignal,
   address,
 }: UseBalanceInput<TConfig>) {
   const { rpc } = useSolanaClient();
@@ -33,7 +34,7 @@ export function useBalance<TConfig extends RpcConfig = RpcConfig>({
     enabled: !!address,
     queryKey: [GILL_HOOK_CLIENT_KEY, "getBalance", address],
     queryFn: async () => {
-      const { value } = await rpc.getBalance(address as Address, config).send();
+      const { value } = await rpc.getBalance(address as Address, config).send({ abortSignal });
       return value;
     },
   });

--- a/packages/react/src/hooks/latest-blockhash.ts
+++ b/packages/react/src/hooks/latest-blockhash.ts
@@ -21,13 +21,14 @@ type UseLatestBlockhashInput<TConfig extends RpcConfig = RpcConfig> = GillUseRpc
 export function useLatestBlockhash<TConfig extends RpcConfig = RpcConfig>({
   options,
   config,
+  abortSignal,
 }: UseLatestBlockhashInput<TConfig> = {}) {
   const { rpc } = useSolanaClient();
   const { data, ...rest } = useQuery({
     ...options,
     queryKey: [GILL_HOOK_CLIENT_KEY, "getLatestBlockhash"],
     queryFn: async () => {
-      const { value } = await rpc.getLatestBlockhash(config).send();
+      const { value } = await rpc.getLatestBlockhash(config).send({ abortSignal });
       return value;
     },
   });

--- a/packages/react/src/hooks/program-accounts.ts
+++ b/packages/react/src/hooks/program-accounts.ts
@@ -65,6 +65,7 @@ type UseProgramAccountsResponse<TConfig extends RpcConfig> = TConfig extends {
 export function useProgramAccounts<TConfig extends RpcConfig = RpcConfig>({
   options,
   config,
+  abortSignal,
   program,
 }: UseProgramAccountsInput<TConfig>) {
   const { rpc } = useSolanaClient();
@@ -74,7 +75,7 @@ export function useProgramAccounts<TConfig extends RpcConfig = RpcConfig>({
     enabled: !!program,
     queryKey: [GILL_HOOK_CLIENT_KEY, "getProgramAccounts", program],
     queryFn: async () => {
-      const accounts = await rpc.getProgramAccounts(program as Address, config).send();
+      const accounts = await rpc.getProgramAccounts(program as Address, config).send({ abortSignal });
       return accounts;
     },
   });

--- a/packages/react/src/hooks/signature-statuses.ts
+++ b/packages/react/src/hooks/signature-statuses.ts
@@ -25,6 +25,7 @@ type UseSignatureStatusesResponse = ReturnType<GetSignatureStatusesApi["getSigna
 export function useSignatureStatuses<TConfig extends RpcConfig = RpcConfig>({
   options,
   config,
+  abortSignal,
   signatures,
 }: UseSignatureStatusesInput<TConfig>) {
   const { rpc } = useSolanaClient();
@@ -33,7 +34,7 @@ export function useSignatureStatuses<TConfig extends RpcConfig = RpcConfig>({
     enabled: signatures && signatures.length > 0,
     queryKey: [GILL_HOOK_CLIENT_KEY, "getSignatureStatuses", signatures],
     queryFn: async () => {
-      const { value } = await rpc.getSignatureStatuses(signatures as Signature[], config).send();
+      const { value } = await rpc.getSignatureStatuses(signatures as Signature[], config).send({ abortSignal });
       return value;
     },
   });

--- a/packages/react/src/hooks/types.ts
+++ b/packages/react/src/hooks/types.ts
@@ -14,4 +14,11 @@ export type GillUseRpcHook<TConfig, TOptions extends GillUseQueryDefaultOptions 
    * Options passed to the {@link useQuery} hook
    */
   options?: Simplify<TOptions>;
+  /**
+   * Signal used to abort the RPC operation
+   *
+   * See MDN docs for {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal | AbortSignal}
+   * and {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortController | AbortController}
+   */
+  abortSignal?: AbortSignal;
 };


### PR DESCRIPTION

### Summary of Changes

accept an abort signal for all the existing hooks as part of the standard gill rpc hook interface