### PR TITLE
feat: initialize token account hook for fetching ata info

### DIFF
--- a/.changeset/stale-panthers-fetch.md
+++ b/.changeset/stale-panthers-fetch.md
@@ -1,0 +1,5 @@
+---
+"gill-react": minor
+---
+
+added `useTokenAccount` hook

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,20 +43,10 @@ yarn add gill gill-react @tanstack/react-query
 
 Setup and configure your `SolanaProvider` to use the gill hooks:
 
-- [Overview](#overview)
-- [Installation](#installation)
-- [Quick start](#quick-start)
-  - [Wrap your React app in a context provider](#wrap-your-react-app-in-a-context-provider)
-  - [Create a client-only provider for NextJs and React server components](#create-a-client-only-provider-for-nextjs-and-react-server-components)
-  - [Wrap your app in the client-only provider for NextJs](#wrap-your-app-in-the-client-only-provider-for-nextjs)
-  - [Using React hooks in React server component applications](#using-react-hooks-in-react-server-component-applications)
-  - [Get your Solana client](#get-your-solana-client)
-  - [Get account balance (in lamports)](#get-account-balance-in-lamports)
-  - [Get latest blockhash](#get-latest-blockhash)
-  - [Get account info (and data)](#get-account-info-and-data)
-  - [Get signature statuses](#get-signature-statuses)
-  - [Get program accounts (GPA)](#get-program-accounts-gpa)
-  - [Get token account](#get-token-account)
+- [Wrap your React app in a context provider](#wrap-your-react-app-in-a-context-provider)
+- [Create a client-only provider for NextJs and React server components](#create-a-client-only-provider-for-nextjs-and-react-server-components)
+- [Wrap your app in the client-only provider for NextJs](#wrap-your-app-in-the-client-only-provider-for-nextjs)
+- [Using React hooks in React server component applications](#using-react-hooks-in-react-server-component-applications)
 
 Manage and use your Solana client's connections:
 
@@ -71,7 +61,6 @@ Fetch data from the Solana blockchain with the gill hooks:
 - [`useLatestBlockhash`](#get-latest-blockhash) - get the latest blockhash
 - [`useProgramAccounts`](#get-program-accounts-gpa) - get program accounts (GPA)
 - [`useSignatureStatuses`](#get-signature-statuses) - get signature statuses
-- [`useTokenAccount`](#get-token-account) - get the token account for a given mint and owner (or ATA)
 
 ### Wrap your React app in a context provider
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -61,6 +61,7 @@ Fetch data from the Solana blockchain with the gill hooks:
 - [`useLatestBlockhash`](#get-latest-blockhash) - get the latest blockhash
 - [`useProgramAccounts`](#get-program-accounts-gpa) - get program accounts (GPA)
 - [`useSignatureStatuses`](#get-signature-statuses) - get signature statuses
+- [`useTokenAccount`](#get-token-account) - get the token account for a given mint and owner (or ATA)
 
 ### Wrap your React app in a context provider
 
@@ -346,7 +347,7 @@ import { useTokenAccount } from "gill-react";
 
 export function PageClient() {
   const { account, isLoading, isError, error } = useTokenAccount({
-    mint: "2t1y8j6j5e8t7u9t9a9v9w9e9r9y9p9o9u9z9y9x9w9t9y9",
+    mint: "7qzuHmauMFA9eTCsS5M7YP6y1HCoyPhkF8g5gdQ8pump",
     owner: "nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c",
   });
 
@@ -369,7 +370,7 @@ import { useTokenAccount } from "gill-react";
 
 export function PageClient() {
   const { account, isLoading, isError, error } = useTokenAccount({
-    ata: "2t1y8j6j5e8t7u9t9a9v9w9e9r9y9p9o9u9z9y9x9w9t9y9",
+    ata: "6AZXPGb5jA8w63fFSZqdpnQBE4YUQGZvXgFiZ8BXRWSE",
   });
 
   // if (isLoading) { return ... }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,10 +43,20 @@ yarn add gill gill-react @tanstack/react-query
 
 Setup and configure your `SolanaProvider` to use the gill hooks:
 
-- [Wrap your React app in a context provider](#wrap-your-react-app-in-a-context-provider)
-- [Create a client-only provider for NextJs and React server components](#create-a-client-only-provider-for-nextjs-and-react-server-components)
-- [Wrap your app in the client-only provider for NextJs](#wrap-your-app-in-the-client-only-provider-for-nextjs)
-- [Using React hooks in React server component applications](#using-react-hooks-in-react-server-component-applications)
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+  - [Wrap your React app in a context provider](#wrap-your-react-app-in-a-context-provider)
+  - [Create a client-only provider for NextJs and React server components](#create-a-client-only-provider-for-nextjs-and-react-server-components)
+  - [Wrap your app in the client-only provider for NextJs](#wrap-your-app-in-the-client-only-provider-for-nextjs)
+  - [Using React hooks in React server component applications](#using-react-hooks-in-react-server-component-applications)
+  - [Get your Solana client](#get-your-solana-client)
+  - [Get account balance (in lamports)](#get-account-balance-in-lamports)
+  - [Get latest blockhash](#get-latest-blockhash)
+  - [Get account info (and data)](#get-account-info-and-data)
+  - [Get signature statuses](#get-signature-statuses)
+  - [Get program accounts (GPA)](#get-program-accounts-gpa)
+  - [Get token account](#get-token-account)
 
 Manage and use your Solana client's connections:
 
@@ -61,6 +71,7 @@ Fetch data from the Solana blockchain with the gill hooks:
 - [`useLatestBlockhash`](#get-latest-blockhash) - get the latest blockhash
 - [`useProgramAccounts`](#get-program-accounts-gpa) - get program accounts (GPA)
 - [`useSignatureStatuses`](#get-signature-statuses) - get signature statuses
+- [`useTokenAccount`](#get-token-account) - get the token account for a given mint and owner (or ATA)
 
 ### Wrap your React app in a context provider
 
@@ -333,4 +344,52 @@ export function PageClient() {
     </div>
   );
 }
+```
+
+### Get token account
+
+Get the token account for a given mint and owner (or ATA):
+
+```tsx
+"use client";
+
+import { useTokenAccount } from "gill-react";
+
+export function PageClient() {
+  const { account, isLoading, isError, error } = useTokenAccount({
+    mint: "2t1y8j6j5e8t7u9t9a9v9w9e9r9y9p9o9u9z9y9x9w9t9y9",
+    owner: "nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c",
+  });
+
+  // if (isLoading) { return ... }
+  // if (isError) { return ... }
+
+  return (
+    <div className="">
+      <pre>account: {JSON.stringify(account, null, "\t")}</pre>
+    </div>
+  );
+}
+```
+
+**OR:**
+```tsx
+"use client";
+
+import { useTokenAccount } from "gill-react";
+
+export function PageClient() {
+  const { account, isLoading, isError, error } = useTokenAccount({
+    ata: "2t1y8j6j5e8t7u9t9a9v9w9e9r9y9p9o9u9z9y9x9w9t9y9",
+  });
+
+  // if (isLoading) { return ... }
+  // if (isError) { return ... }
+
+  return (
+    <div className="">
+      <pre>account: {JSON.stringify(account, null, "\t")}</pre>
+    </div>
+  );
+} 
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -224,7 +224,7 @@ export function PageClient() {
 Get the account info for an address using the Solana RPC method of
 [`getAccountInfo`](https://solana.com/docs/rpc/http/getaccountinfo):
 
-> See also: [useTokenMint](#get-token-mint-account)
+> See also: [useTokenMint](#get-token-mint-account) and [`useTokenAccount`](#get-token-account)
 
 ```tsx
 "use client";
@@ -251,8 +251,9 @@ You can also provide a `Decoder` for known account data structure in order to de
 object:
 
 > ![NOTE] Some popular account types may have their own dedicated hook, like
-> [Token Mints (`useTokenMint`)](#get-token-mint-account). If a dedicated hook exists for an account type, it is highly
-> recommended to use those hooks as opposed to manually providing a `decoder` to `useAccount()`.
+> [Token Mints (`useTokenMint`)](#get-token-mint-account) and and [`useTokenAccount`](#get-token-account). If a
+> dedicated hook exists for an account type, it is highly recommended to use those hooks as opposed to manually
+> providing a `decoder` to `useAccount()`.
 
 ```tsx
 "use client";
@@ -373,7 +374,7 @@ export function PageClient() {
 
 ### Get token account
 
-Get the token account for a given mint and owner (or ATA):
+Get the token account for a given mint and owner:
 
 ```tsx
 "use client";
@@ -382,8 +383,9 @@ import { useTokenAccount } from "gill-react";
 
 export function PageClient() {
   const { account, isLoading, isError, error } = useTokenAccount({
-    mint: "7qzuHmauMFA9eTCsS5M7YP6y1HCoyPhkF8g5gdQ8pump",
-    owner: "nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c",
+    // token on devnet
+    mint: "HwxZNMkZbZMeiu9Xnmc6Rg8jYgNsJB47jwabHGUebW4F",
+    owner: "nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5",
   });
 
   // if (isLoading) { return ... }
@@ -397,7 +399,10 @@ export function PageClient() {
 }
 ```
 
-**OR:**
+If you already know the specific Associated Token Account's address (ATA), then you can get that specific token account
+by providing the `ata` address:
+
+> Note: This is most commonly used for multi-sig protocols like Squads.
 
 ```tsx
 "use client";
@@ -406,7 +411,7 @@ import { useTokenAccount } from "gill-react";
 
 export function PageClient() {
   const { account, isLoading, isError, error } = useTokenAccount({
-    ata: "6AZXPGb5jA8w63fFSZqdpnQBE4YUQGZvXgFiZ8BXRWSE",
+    ata: "CCMCWh4FudPEmY6Q1AVi5o8mQMXkHYkJUmZfzRGdcJ9P",
   });
 
   // if (isLoading) { return ... }

--- a/packages/react/src/__typeset__/token-account.ts
+++ b/packages/react/src/__typeset__/token-account.ts
@@ -1,0 +1,34 @@
+import { Account, Address } from "gill";
+
+import { useTokenAccount } from "../hooks/token-account";
+
+// [DESCRIBE] useTokenAccount
+{
+  const mint = null as unknown as Address<"12345">;
+  const owner = null as unknown as Address<"12345">;
+  const ata = null as unknown as Address<"12345">;
+
+  // Should accept mint and owner
+  {
+    const { account } = useTokenAccount({ mint, owner });
+    // Should have `exists=true` declared
+    account satisfies { exists: true };
+    // Should be a Uint8Array for the data
+    account satisfies Account<Uint8Array>;
+
+    // @ts-expect-error - Should not allow no argument
+    useTokenAccount();
+
+    // @ts-expect-error - Should not allow empty argument object
+    useTokenAccount({});
+  }
+
+  // Should accept `ata` input`
+  {
+    const { account } = useTokenAccount({ ata });
+    // Should have `exists=true` declared
+    account satisfies { exists: true };
+    // Should be a Uint8Array for the data
+    account satisfies Account<Uint8Array>;
+  }
+}

--- a/packages/react/src/__typeset__/token-account.ts
+++ b/packages/react/src/__typeset__/token-account.ts
@@ -1,20 +1,21 @@
 import { Account, Address } from "gill";
 
 import { useTokenAccount } from "../hooks/token-account";
+import { Token } from "gill/programs/token";
 
 // [DESCRIBE] useTokenAccount
 {
-  const mint = null as unknown as Address<"12345">;
-  const owner = null as unknown as Address<"12345">;
-  const ata = null as unknown as Address<"12345">;
+  const mint = null as unknown as Address<"mint">;
+  const owner = null as unknown as Address<"owner">;
+  const ata = null as unknown as Address<"ata">;
 
-  // Should accept mint and owner
+  // Should accept `mint` and `owner`
   {
     const { account } = useTokenAccount({ mint, owner });
     // Should have `exists=true` declared
     account satisfies { exists: true };
-    // Should be a Uint8Array for the data
-    account satisfies Account<Uint8Array>;
+    // Should be a Token for the data
+    account satisfies Account<Token>;
 
     // @ts-expect-error - Should not allow no argument
     useTokenAccount();
@@ -23,12 +24,39 @@ import { useTokenAccount } from "../hooks/token-account";
     useTokenAccount({});
   }
 
-  // Should accept `ata` input`
+  // Should accept `ata` input
   {
     const { account } = useTokenAccount({ ata });
     // Should have `exists=true` declared
     account satisfies { exists: true };
-    // Should be a Uint8Array for the data
-    account satisfies Account<Uint8Array>;
+    // Should be a Token for the data
+    account satisfies Account<Token>;
+    // Should use the address type
+    account.address satisfies Address<"ata">;
+  }
+
+  // Should accept `config` input with `ata`
+  {
+    const { account } = useTokenAccount({
+      ata,
+      config: { commitment: "confirmed" },
+    });
+    // Should have `exists=true` declared
+    account satisfies { exists: true };
+    // Should be a parsed `Token` for the data
+    account satisfies Account<Token>;
+  }
+
+  // Should accept `config` input with `mint` and `owner`
+  {
+    const { account } = useTokenAccount({
+      mint,
+      owner,
+      config: { commitment: "confirmed" },
+    });
+    // Should have `exists=true` declared
+    account satisfies { exists: true };
+    // Should be a parsed `Token` for the data
+    account satisfies Account<Token>;
   }
 }

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -4,4 +4,5 @@ export * from "./client";
 export * from "./latest-blockhash";
 export * from "./program-accounts";
 export * from "./signature-statuses";
+export * from "./token-account";
 export * from "./token-mint";

--- a/packages/react/src/hooks/token-account.ts
+++ b/packages/react/src/hooks/token-account.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { Account, Address, Decoder, FetchAccountConfig, Simplify } from "gill";
+import { address, assertAccountExists, decodeAccount, fetchEncodedAccount } from "gill";
+import { getAssociatedTokenAccountAddress, TOKEN_2022_PROGRAM_ADDRESS } from "gill/programs/token";
+
+import { GILL_HOOK_CLIENT_KEY } from "../const";
+import { useSolanaClient } from "./client";
+import type { GillUseRpcHook } from "./types";
+
+type RpcConfig = Simplify<Omit<FetchAccountConfig, "abortSignal">>;
+
+type UseTokenAccountResponse<TData extends Uint8Array | object = Uint8Array> = Account<TData> & {
+  exists: true;
+};
+
+type UseTokenAccountInput<
+  TConfig extends RpcConfig = RpcConfig,
+  TDecodedData extends object = Uint8Array,
+> = GillUseRpcHook<TConfig> & {
+  /**
+   * Optional manual ATA override (useful for multi-sig setups)
+   */
+  ataOverride?: Address;
+  /**
+   * Account decoder for token account data
+   */
+  decoder?: Decoder<TDecodedData>;
+  /**
+   * Mint address of the SPL token
+   */
+  mint: Address;
+  /**
+   * Owner of the token account
+   */
+  owner: Address;
+  /**
+   * Use Token-2022 instead of the default SPL Token Program
+   */
+  useToken2022?: boolean;
+};
+
+/**
+ * Fetch the associated token account (ATA) for a given mint & owner.
+ * Supports Token-2022 via the `useToken2022` flag.
+ */
+export function useTokenAccount<TConfig extends RpcConfig = RpcConfig, TDecodedData extends object = Uint8Array>({
+  options,
+  config,
+  abortSignal,
+  mint,
+  owner,
+  ataOverride,
+  decoder,
+  useToken2022 = false,
+}: UseTokenAccountInput<TConfig, TDecodedData>) {
+  const { rpc } = useSolanaClient();
+
+  if (abortSignal) {
+    // @ts-expect-error the `abortSignal` was stripped from the type but is now being adding back in
+    config = {
+      ...(config || {}),
+      abortSignal,
+    };
+  }
+
+  //   Supporting Token-2022 and SPL Token Programs
+  const tokenProgram = useToken2022 ? TOKEN_2022_PROGRAM_ADDRESS : undefined;
+
+  const { data, ...rest } = useQuery({
+    networkMode: "offlineFirst",
+    ...options,
+    enabled: !!mint && !!owner,
+    queryFn: async () => {
+      // Derive ATA if not manually provided
+      const ata = ataOverride
+        ? address(ataOverride)
+        : await getAssociatedTokenAccountAddress(address(mint), address(owner), tokenProgram);
+
+      const account = await fetchEncodedAccount(rpc, ata, config);
+      assertAccountExists(account);
+
+      return decoder ? decodeAccount(account, decoder as Decoder<TDecodedData>) : account;
+    },
+    queryKey: [GILL_HOOK_CLIENT_KEY, "getTokenAccount", mint, owner, useToken2022],
+  });
+
+  return {
+    ...rest,
+    account: data as UseTokenAccountResponse<TDecodedData>,
+  };
+}

--- a/packages/react/src/hooks/token-account.ts
+++ b/packages/react/src/hooks/token-account.ts
@@ -24,16 +24,27 @@ type UseTokenAccountResponse<TAddress extends Address = Address> = Simplify<
 >;
 
 type TokenAccountInputWithDeclaredAta<TAddress extends Address = Address> = {
+  /**
+   * Address of the {@link https://solana.com/docs/tokens#associated-token-account | Token Account} to get and decode
+   */
   ata: TAddress;
 };
 
 type TokenAccountInputWithDerivedAtaDetails = {
+  /**
+   * Address of the {@link https://solana.com/docs/tokens#token-account | Token Account}'s `owner`
+   */
   owner: Address;
   /**
-   * Address of the Mint account to get and decode
+   * Address of the {@link https://solana.com/docs/tokens#token-account | Token Account}'s `mint`
    */
   mint: Address;
-
+  /**
+   * The {@link https://solana.com/docs/tokens#token-programs | Token Program} used to create the `mint`
+   *
+   * If no `tokenProgram` is provided, the hook will automatically fetch the
+   * {@link https://solana.com/docs/tokens#mint-account | Mint account} to retrieve the correct Token Program address
+   */
   tokenProgram?: Address;
 };
 


### PR DESCRIPTION
### Problem
create `useTokenAccount` hook for fetching and decode associated token accounts

### Summary of Changes
- Initializes creation of the hook
- If ATA not explicitly provided, derive based on mint, and owner's address


Fixes #93 