### PR TITLE
[fix] transaction builders do not allow `Address` as `feePayer`

### DIFF
--- a/.changeset/chilly-scissors-swim.md
+++ b/.changeset/chilly-scissors-swim.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+fixed token builders to accept address or signer as fee payer

--- a/packages/gill/src/__tests__/mint-tokens-instructions.ts
+++ b/packages/gill/src/__tests__/mint-tokens-instructions.ts
@@ -3,7 +3,7 @@ import {
   getMintToInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
-import type { Address, KeyPairSigner } from "@solana/kit";
+import { generateKeyPairSigner, type Address, type KeyPairSigner } from "@solana/kit";
 import { getMintTokensInstructions, GetMintTokensInstructionsArgs, TOKEN_PROGRAM_ADDRESS } from "../programs/token";
 
 // Mock the imported functions
@@ -16,13 +16,22 @@ jest.mock("@solana-program/token-2022", () => ({
 }));
 
 describe("getMintTokensInstructions", () => {
-  const mockPayer = { address: "payer" } as KeyPairSigner;
-  const mockMint = { address: "mint" } as KeyPairSigner;
-  const mockMintAuthority = { address: "mintAuthority" } as KeyPairSigner;
-  const mockDestination = { address: "destination" } as KeyPairSigner;
+  let mockPayer: KeyPairSigner;
+  let mockMint: KeyPairSigner;
+  let mockMintAuthority: KeyPairSigner;
+  let mockDestination: KeyPairSigner;
 
   const mockAta = "mockAtaAddress" as Address;
   const mockAmount = BigInt(1000);
+
+  beforeAll(async () => {
+    [mockPayer, mockMint, mockMintAuthority, mockDestination] = await Promise.all([
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+    ]);
+  });
 
   beforeEach(() => {
     (getCreateAssociatedTokenIdempotentInstruction as jest.Mock).mockReturnValue({

--- a/packages/gill/src/__tests__/transfer-tokens-instructions.ts
+++ b/packages/gill/src/__tests__/transfer-tokens-instructions.ts
@@ -3,7 +3,7 @@ import {
   getTransferInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
-import type { Address, KeyPairSigner } from "@solana/kit";
+import { generateKeyPairSigner, type Address, type KeyPairSigner } from "@solana/kit";
 import {
   getTransferTokensInstructions,
   GetTransferTokensInstructionsArgs,
@@ -20,14 +20,23 @@ jest.mock("@solana-program/token-2022", () => ({
 }));
 
 describe("getTransferTokensInstructions", () => {
-  const mockPayer = { address: "payer" } as KeyPairSigner;
-  const mockMint = { address: "mint" } as KeyPairSigner;
-  const mockAuthority = { address: "authority" } as KeyPairSigner;
-  const mockDestination = { address: "destination" } as KeyPairSigner;
+  let mockPayer = { address: "payer" } as KeyPairSigner;
+  let mockMint = { address: "mint" } as KeyPairSigner;
+  let mockAuthority = { address: "authority" } as KeyPairSigner;
+  let mockDestination = { address: "destination" } as KeyPairSigner;
   const mockDestinationAta = "destinationAta" as Address;
   const mockSourceAta = "sourceAta" as Address;
 
   const mockAmount = BigInt(1000);
+
+  beforeAll(async () => {
+    [mockPayer, mockMint, mockAuthority, mockDestination] = await Promise.all([
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+      generateKeyPairSigner(),
+    ]);
+  });
 
   beforeEach(() => {
     (getCreateAssociatedTokenIdempotentInstruction as jest.Mock).mockReturnValue({

--- a/packages/gill/src/__typetests__/create-transaction.ts
+++ b/packages/gill/src/__typetests__/create-transaction.ts
@@ -73,6 +73,14 @@ import { createTransaction } from "../core";
       TransactionMessageWithBlockhashLifetime &
       ITransactionMessageWithFeePayer;
 
+    createTransaction({
+      version: "legacy",
+      feePayer: feePayer,
+      instructions: [ix],
+      latestBlockhash,
+      // @ts-expect-error Should not be a "fee payer signer"
+    }) satisfies ITransactionMessageWithFeePayerSigner;
+
     // Should be a signable transaction
     signTransactionMessageWithSigners(txSignable);
   }
@@ -127,6 +135,14 @@ import { createTransaction } from "../core";
       instructions: [ix],
       latestBlockhash,
     }) satisfies BaseTransactionMessage<0> & TransactionMessageWithBlockhashLifetime & ITransactionMessageWithFeePayer;
+
+    createTransaction({
+      version: 0,
+      feePayer: feePayer,
+      instructions: [ix],
+      latestBlockhash,
+      // @ts-expect-error Should not be a "fee payer signer"
+    }) satisfies ITransactionMessageWithFeePayerSigner;
 
     // Should be a signable transaction
     signTransactionMessageWithSigners(txSignable);

--- a/packages/gill/src/core/create-transaction.ts
+++ b/packages/gill/src/core/create-transaction.ts
@@ -33,7 +33,14 @@ export function createTransaction<TVersion extends TransactionVersion, TFeePayer
 ): FullTransaction<TVersion, ITransactionMessageWithFeePayer>;
 export function createTransaction<
   TVersion extends TransactionVersion,
-  TFeePayer extends Address | TransactionSigner,
+  TFeePayer extends TransactionSigner,
+  TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
+>(
+  props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
+): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner, TransactionMessageWithBlockhashLifetime>>;
+export function createTransaction<
+  TVersion extends TransactionVersion,
+  TFeePayer extends Address,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
@@ -44,7 +51,7 @@ export function createTransaction<
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
-): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner, TransactionMessageWithBlockhashLifetime>>;
+): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
 export function createTransaction<TVersion extends TransactionVersion, TFeePayer extends Address | TransactionSigner>({
   version,
   feePayer,

--- a/packages/gill/src/core/create-transaction.ts
+++ b/packages/gill/src/core/create-transaction.ts
@@ -33,14 +33,14 @@ export function createTransaction<TVersion extends TransactionVersion, TFeePayer
 ): FullTransaction<TVersion, ITransactionMessageWithFeePayer>;
 export function createTransaction<
   TVersion extends TransactionVersion,
-  TFeePayer extends Address,
+  TFeePayer extends Address | TransactionSigner,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
 ): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
 export function createTransaction<
   TVersion extends TransactionVersion,
-  TFeePayer extends TransactionSigner,
+  TFeePayer extends Address | TransactionSigner,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,

--- a/packages/gill/src/core/utils.ts
+++ b/packages/gill/src/core/utils.ts
@@ -1,4 +1,10 @@
-import { createNoopSigner, isTransactionSigner, type Address, type TransactionSigner } from "@solana/kit";
+import {
+  assertIsTransactionSigner,
+  createNoopSigner,
+  isTransactionSigner,
+  type Address,
+  type TransactionSigner,
+} from "@solana/kit";
 import type { SolanaClusterMoniker } from "../types";
 import { GENESIS_HASH } from "./const";
 
@@ -20,15 +26,19 @@ export function getMonikerFromGenesisHash(hash: string): SolanaClusterMoniker | 
   }
 }
 
-export function checkedAddress(input: Address | TransactionSigner): Address {
+export function checkedAddress<TAddress extends string = string>(
+  input: Address<TAddress> | TransactionSigner<TAddress>,
+): Address<TAddress> {
   return typeof input == "string" ? input : input.address;
 }
 
-export function checkedTransactionSigner(input: Address | TransactionSigner): TransactionSigner {
-  if (typeof input === "string" || "address" in input == false) {
-    return createNoopSigner(input);
-  } else if (isTransactionSigner(input)) return input;
-  throw new Error("A signer or address is required");
+export function checkedTransactionSigner<TAddress extends string = string>(
+  input: Address<TAddress> | TransactionSigner<TAddress>,
+): TransactionSigner<TAddress> {
+  if (typeof input === "string" || "address" in input == false) input = createNoopSigner(input);
+  if (!isTransactionSigner(input)) throw new Error("A signer or address is required");
+  assertIsTransactionSigner(input);
+  return input;
 }
 
 /**

--- a/packages/gill/src/core/utils.ts
+++ b/packages/gill/src/core/utils.ts
@@ -1,5 +1,4 @@
-import type { Address, KeyPairSigner } from "@solana/kit";
-
+import { createNoopSigner, isTransactionSigner, type Address, type TransactionSigner } from "@solana/kit";
 import type { SolanaClusterMoniker } from "../types";
 import { GENESIS_HASH } from "./const";
 
@@ -21,8 +20,15 @@ export function getMonikerFromGenesisHash(hash: string): SolanaClusterMoniker | 
   }
 }
 
-export function checkedAddress(input: Address | KeyPairSigner): Address {
+export function checkedAddress(input: Address | TransactionSigner): Address {
   return typeof input == "string" ? input : input.address;
+}
+
+export function checkedTransactionSigner(input: Address | TransactionSigner): TransactionSigner {
+  if (typeof input === "string" || "address" in input == false) {
+    return createNoopSigner(input);
+  } else if (isTransactionSigner(input)) return input;
+  throw new Error("A signer or address is required");
 }
 
 /**

--- a/packages/gill/src/programs/token/addresses.ts
+++ b/packages/gill/src/programs/token/addresses.ts
@@ -1,5 +1,5 @@
 import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
-import { isAddress, type Address, type KeyPairSigner } from "@solana/kit";
+import { isAddress, type Address, type TransactionSigner } from "@solana/kit";
 import { checkedAddress } from "../../core/utils";
 
 export type LegacyTokenProgramMonikers = "legacy" | "token";
@@ -22,8 +22,8 @@ export const TOKEN_PROGRAM_ADDRESS =
  * - {@link TOKEN_2022_PROGRAM_ADDRESS} - the SPL Token Extensions Program (aka Token22)
  */
 export async function getAssociatedTokenAccountAddress(
-  mint: Address | KeyPairSigner,
-  owner: Address | KeyPairSigner,
+  mint: Address | TransactionSigner,
+  owner: Address | TransactionSigner,
   tokenProgram?: Address,
 ): Promise<Address> {
   return (

--- a/packages/gill/src/programs/token/instructions/create-token.ts
+++ b/packages/gill/src/programs/token/instructions/create-token.ts
@@ -1,6 +1,6 @@
 import { getCreateAccountInstruction } from "@solana-program/system";
-import type { Address, IInstruction, KeyPairSigner } from "@solana/kit";
-import { checkedAddress, getMinimumBalanceForRentExemption } from "../../../core";
+import type { Address, IInstruction, KeyPairSigner, TransactionSigner } from "@solana/kit";
+import { checkedAddress, checkedTransactionSigner, getMinimumBalanceForRentExemption } from "../../../core";
 import { getCreateMetadataAccountV3Instruction, getTokenMetadataAddress } from "../../token-metadata";
 
 import {
@@ -26,20 +26,20 @@ export type GetCreateTokenInstructionsArgs = TokenInstructionBase<KeyPairSigner>
    *
    * When not provided, defaults to: `feePayer`
    **/
-  mintAuthority?: KeyPairSigner;
+  mintAuthority?: TransactionSigner;
   /**
    * Authority address that is able to freeze (and thaw) user owned token accounts.
    * When a user's token account is frozen, they will not be able to transfer their tokens.
    *
    * When not provided, defaults to: `null`
    **/
-  freezeAuthority?: Address | KeyPairSigner;
+  freezeAuthority?: Address | TransactionSigner;
   /**
    * Authority address that is allowed to update the metadata
    *
    * When not provided, defaults to: `feePayer`
    **/
-  updateAuthority?: KeyPairSigner;
+  updateAuthority?: TransactionSigner;
   /**
    * Optional (but highly recommended) metadata to attach to this token
    */
@@ -77,7 +77,9 @@ export type GetCreateTokenInstructionsArgs = TokenInstructionBase<KeyPairSigner>
  */
 export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs): IInstruction[] {
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
+  args.feePayer = checkedTransactionSigner(args.feePayer);
 
+  // if (isAddress) args.feePayer =
   if (!args.decimals) args.decimals = 9;
   if (!args.mintAuthority) args.mintAuthority = args.feePayer;
   if (!args.updateAuthority) args.updateAuthority = args.feePayer;

--- a/packages/gill/src/programs/token/instructions/create-token.ts
+++ b/packages/gill/src/programs/token/instructions/create-token.ts
@@ -79,7 +79,6 @@ export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs)
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
   args.feePayer = checkedTransactionSigner(args.feePayer);
 
-  // if (isAddress) args.feePayer =
   if (!args.decimals) args.decimals = 9;
   if (!args.mintAuthority) args.mintAuthority = args.feePayer;
   if (!args.updateAuthority) args.updateAuthority = args.feePayer;

--- a/packages/gill/src/programs/token/instructions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/instructions/mint-tokens.ts
@@ -1,20 +1,20 @@
-import type { Address, IInstruction, KeyPairSigner } from "@solana/kit";
+import type { Address, IInstruction, TransactionSigner } from "@solana/kit";
 
 import { getCreateAssociatedTokenIdempotentInstruction, getMintToInstruction } from "@solana-program/token-2022";
 import { checkedAddress, checkedTransactionSigner } from "../../../core";
 import { checkedTokenProgramAddress } from "../addresses";
 import type { TokenInstructionBase } from "./types";
 
-export type GetMintTokensInstructionsArgs = TokenInstructionBase<KeyPairSigner | Address> & {
+export type GetMintTokensInstructionsArgs = TokenInstructionBase & {
   /**
    * The authority address capable of authorizing minting of new tokens.
    *
-   * - this should normally by a `KeyPairSigner`
+   * - this should normally by a `TransactionSigner`
    * - only for multi-sig authorities (like Squads Protocol), should you supply an `Address`
    * */
-  mintAuthority: KeyPairSigner | Address;
+  mintAuthority: TransactionSigner | Address;
   /** Wallet address to receive the tokens being minted, via their associated token account (ata) */
-  destination: KeyPairSigner | Address;
+  destination: TransactionSigner | Address;
   /**
    * Associated token account (ata) address for `destination` and this `mint`
    *

--- a/packages/gill/src/programs/token/instructions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/instructions/mint-tokens.ts
@@ -1,7 +1,7 @@
 import type { Address, IInstruction, KeyPairSigner } from "@solana/kit";
 
 import { getCreateAssociatedTokenIdempotentInstruction, getMintToInstruction } from "@solana-program/token-2022";
-import { checkedAddress } from "../../../core";
+import { checkedAddress, checkedTransactionSigner } from "../../../core";
 import { checkedTokenProgramAddress } from "../addresses";
 import type { TokenInstructionBase } from "./types";
 
@@ -57,6 +57,7 @@ export type GetMintTokensInstructionsArgs = TokenInstructionBase<KeyPairSigner |
  */
 export function getMintTokensInstructions(args: GetMintTokensInstructionsArgs): IInstruction[] {
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
+  args.feePayer = checkedTransactionSigner(args.feePayer);
   args.mint = checkedAddress(args.mint);
 
   return [

--- a/packages/gill/src/programs/token/instructions/transfer-tokens.ts
+++ b/packages/gill/src/programs/token/instructions/transfer-tokens.ts
@@ -1,7 +1,7 @@
 import type { Address, IInstruction, KeyPairSigner } from "@solana/kit";
 
 import { getCreateAssociatedTokenIdempotentInstruction, getTransferInstruction } from "@solana-program/token-2022";
-import { checkedAddress } from "../../../core";
+import { checkedAddress, checkedTransactionSigner } from "../../../core";
 import { checkedTokenProgramAddress } from "../addresses";
 import type { TokenInstructionBase } from "./types";
 
@@ -66,6 +66,7 @@ export type GetTransferTokensInstructionsArgs = TokenInstructionBase<KeyPairSign
  */
 export function getTransferTokensInstructions(args: GetTransferTokensInstructionsArgs): IInstruction[] {
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
+  args.feePayer = checkedTransactionSigner(args.feePayer);
   args.mint = checkedAddress(args.mint);
 
   return [

--- a/packages/gill/src/programs/token/instructions/transfer-tokens.ts
+++ b/packages/gill/src/programs/token/instructions/transfer-tokens.ts
@@ -1,17 +1,17 @@
-import type { Address, IInstruction, KeyPairSigner } from "@solana/kit";
+import type { Address, IInstruction, TransactionSigner } from "@solana/kit";
 
 import { getCreateAssociatedTokenIdempotentInstruction, getTransferInstruction } from "@solana-program/token-2022";
 import { checkedAddress, checkedTransactionSigner } from "../../../core";
 import { checkedTokenProgramAddress } from "../addresses";
 import type { TokenInstructionBase } from "./types";
 
-export type GetTransferTokensInstructionsArgs = TokenInstructionBase<KeyPairSigner | Address> & {
+export type GetTransferTokensInstructionsArgs = TokenInstructionBase & {
   /**
    * The source account's owner/delegate or its multi-signature account:
-   * - this should normally by a `KeyPairSigner`
+   * - this should normally by a `TransactionSigner`
    * - only for multi-sig authorities (like Squads Protocol), should you supply an `Address`
    * */
-  authority: KeyPairSigner | Address;
+  authority: TransactionSigner | Address;
   /**
    * Associated token account (ata) address for `authority` and this `mint`
    *
@@ -24,7 +24,7 @@ export type GetTransferTokensInstructionsArgs = TokenInstructionBase<KeyPairSign
    * */
   sourceAta: Address;
   /** Wallet address to receive the tokens, via their associated token account: `destinationAta` */
-  destination: KeyPairSigner | Address;
+  destination: TransactionSigner | Address;
   /**
    * Associated token account (ata) address for `destination` and this `mint`
    *

--- a/packages/gill/src/programs/token/instructions/types.ts
+++ b/packages/gill/src/programs/token/instructions/types.ts
@@ -1,10 +1,10 @@
-import type { Address, KeyPairSigner } from "@solana/kit";
-import type { TOKEN_PROGRAM_ADDRESS } from "../addresses";
 import type { TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
+import type { Address, KeyPairSigner, TransactionSigner } from "@solana/kit";
+import type { TOKEN_PROGRAM_ADDRESS } from "../addresses";
 
 export type TokenInstructionBase<TMint = KeyPairSigner | Address> = {
   /** Signer that will pay for the rent storage deposit fee and transaction fees */
-  feePayer: KeyPairSigner;
+  feePayer: Address | TransactionSigner;
   /** Token mint to issue the tokens */
   mint: TMint;
   /**

--- a/packages/gill/src/programs/token/transactions/create-token.ts
+++ b/packages/gill/src/programs/token/transactions/create-token.ts
@@ -6,7 +6,7 @@ import type {
   TransactionSigner,
   TransactionVersion,
 } from "@solana/kit";
-import { createTransaction } from "../../../core";
+import { checkedTransactionSigner, createTransaction } from "../../../core";
 import type { FullTransaction, Simplify } from "../../../types";
 import { getTokenMetadataAddress } from "../../token-metadata";
 import { checkedTokenProgramAddress, TOKEN_PROGRAM_ADDRESS } from "../addresses";
@@ -67,6 +67,7 @@ export async function buildCreateTokenTransaction<
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(args: TransactionBuilderInput<TVersion, TFeePayer, TLifetimeConstraint> & GetCreateTokenTransactionInput) {
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
+  args.feePayer = checkedTransactionSigner(args.feePayer);
 
   let metadataAddress = args.mint.address;
 
@@ -89,7 +90,7 @@ export async function buildCreateTokenTransaction<
 
   return createTransaction(
     (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer,
+      feePayer: feePayer as TransactionSigner,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,

--- a/packages/gill/src/programs/token/transactions/create-token.ts
+++ b/packages/gill/src/programs/token/transactions/create-token.ts
@@ -90,7 +90,7 @@ export async function buildCreateTokenTransaction<
 
   return createTransaction(
     (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer: feePayer as TransactionSigner,
+      feePayer,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,

--- a/packages/gill/src/programs/token/transactions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/transactions/mint-tokens.ts
@@ -94,7 +94,7 @@ export async function buildMintTokensTransaction<
 
   return createTransaction(
     (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer: feePayer as TransactionSigner,
+      feePayer,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,

--- a/packages/gill/src/programs/token/transactions/mint-tokens.ts
+++ b/packages/gill/src/programs/token/transactions/mint-tokens.ts
@@ -5,7 +5,7 @@ import type {
   TransactionSigner,
   TransactionVersion,
 } from "@solana/kit";
-import { checkedAddress, createTransaction } from "../../../core";
+import { checkedAddress, checkedTransactionSigner, createTransaction } from "../../../core";
 import type { FullTransaction, Simplify } from "../../../types";
 import { checkedTokenProgramAddress, getAssociatedTokenAccountAddress } from "../addresses";
 import { getMintTokensInstructions, type GetMintTokensInstructionsArgs } from "../instructions/mint-tokens";
@@ -69,6 +69,7 @@ export async function buildMintTokensTransaction<
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(args: TransactionBuilderInput<TVersion, TFeePayer, TLifetimeConstraint> & GetCreateTokenTransactionInput) {
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
+  args.feePayer = checkedTransactionSigner(args.feePayer);
   args.mint = checkedAddress(args.mint);
 
   if (!args.ata) {
@@ -93,7 +94,7 @@ export async function buildMintTokensTransaction<
 
   return createTransaction(
     (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer,
+      feePayer: feePayer as TransactionSigner,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,

--- a/packages/gill/src/programs/token/transactions/transfer-tokens.ts
+++ b/packages/gill/src/programs/token/transactions/transfer-tokens.ts
@@ -1,6 +1,6 @@
 import type {
   Address,
-  ITransactionMessageWithFeePayerSigner,
+  ITransactionMessageWithFeePayer,
   TransactionMessageWithBlockhashLifetime,
   TransactionSigner,
   TransactionVersion,
@@ -56,7 +56,7 @@ export async function buildTransferTokensTransaction<
   TFeePayer extends TransactionSigner = TransactionSigner,
 >(
   args: TransactionBuilderInput<TVersion, TFeePayer> & GetTransferTokensTransactionInput,
-): Promise<FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner>>;
+): Promise<FullTransaction<TVersion, ITransactionMessageWithFeePayer>>;
 export async function buildTransferTokensTransaction<
   TVersion extends TransactionVersion = "legacy",
   TFeePayer extends TransactionSigner = TransactionSigner,
@@ -64,7 +64,7 @@ export async function buildTransferTokensTransaction<
     TransactionMessageWithBlockhashLifetime["lifetimeConstraint"] = TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   args: TransactionBuilderInput<TVersion, TFeePayer, TLifetimeConstraint> & GetTransferTokensTransactionInput,
-): Promise<FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner, TransactionMessageWithBlockhashLifetime>>;
+): Promise<FullTransaction<TVersion, ITransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
 export async function buildTransferTokensTransaction<
   TVersion extends TransactionVersion,
   TFeePayer extends Address | TransactionSigner,
@@ -99,7 +99,7 @@ export async function buildTransferTokensTransaction<
 
   return createTransaction(
     (({ feePayer, version, computeUnitLimit, computeUnitPrice, latestBlockhash }: typeof args) => ({
-      feePayer: feePayer as TransactionSigner,
+      feePayer,
       version: version || "legacy",
       computeUnitLimit,
       computeUnitPrice,

--- a/packages/gill/src/programs/token/transactions/types.ts
+++ b/packages/gill/src/programs/token/transactions/types.ts
@@ -1,9 +1,14 @@
-import type { TransactionMessageWithBlockhashLifetime, TransactionSigner, TransactionVersion } from "@solana/kit";
+import type {
+  Address,
+  TransactionMessageWithBlockhashLifetime,
+  TransactionSigner,
+  TransactionVersion,
+} from "@solana/kit";
 import type { CreateTransactionInput, Simplify } from "../../../types";
 
 export type TransactionBuilderInput<
   TVersion extends TransactionVersion = "legacy",
-  TFeePayer extends TransactionSigner = TransactionSigner,
+  TFeePayer extends Address | TransactionSigner = TransactionSigner,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"] | undefined = undefined,
 > = Simplify<
   Omit<CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>, "version" | "instructions" | "feePayer"> &


### PR DESCRIPTION
### Problem

the transaction builders should accept an address or signer as the feePayer, but only actually accepts a `KeypairSigner`. making them really only usable in backend scripts that know the full keypair. not in frontend apps that use wallet ui to manage the user's secrey key

### Summary of Changes

- update all the types for transaction builders to allow address or transaction signers
- when an address is supplied, it is auto upgraded to a `NoopSigner`

Fixes #98