### PR TITLE
docs: fix 'bas58' typo in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also find some [NodeJS specific helpers](#node-specific-imports) like:
 - [Saving a keypair to a file](#saving-a-keypair-to-a-file)
 - [Loading a keypair from an environment variable](#loading-a-keypair-from-an-environment-variable)
 - [Saving a keypair to an environment variable file](#saving-a-keypair-to-an-environment-file)
-- [Loading a bas58 keypair from an environment variable](#loading-a-base58-keypair-from-an-environment-variable)
+- [Loading a base58 keypair from an environment variable](#loading-a-base58-keypair-from-an-environment-variable)
 
 You can find [transaction builders](#transaction-builders) for common tasks, including:
 

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -70,7 +70,7 @@ You can also find some [NodeJS specific helpers](#node-specific-imports) like:
 - [Saving a keypair to a file](#saving-a-keypair-to-a-file)
 - [Loading a keypair from an environment variable](#loading-a-keypair-from-an-environment-variable)
 - [Saving a keypair to an environment variable file](#saving-a-keypair-to-an-environment-file)
-- [Loading a bas58 keypair from an environment variable](#loading-a-base58-keypair-from-an-environment-variable)
+- [Loading a base58 keypair from an environment variable](#loading-a-base58-keypair-from-an-environment-variable)
 
 You can find [transaction builders](#transaction-builders) for common tasks, including:
 


### PR DESCRIPTION
### Problem

`bas58` text being used in README files where `base58` should be used instead.

### Summary of Changes

`bas58` entries replaced with `base58`.