### PR TITLE
chore: removed ts-ignore

### DIFF
--- a/.changeset/hot-lamps-scream.md
+++ b/.changeset/hot-lamps-scream.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+removed the ts-ignore on create token as it is no longer needed

--- a/packages/gill/src/programs/token/instructions/create-token.ts
+++ b/packages/gill/src/programs/token/instructions/create-token.ts
@@ -85,13 +85,11 @@ export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs)
   if (args.freezeAuthority) args.freezeAuthority = checkedAddress(args.freezeAuthority);
 
   if (args.tokenProgram === TOKEN_2022_PROGRAM_ADDRESS) {
-    // @ts-ignore FIXME(nick): errors due to not finding the valid overload
     const metadataPointer = extension("MetadataPointer", {
       metadataAddress: args.mint.address,
       authority: args.updateAuthority.address,
     });
 
-    // @ts-ignore FIXME(nick): errors due to not finding the valid overload
     const metadataExtensionData = extension("TokenMetadata", {
       updateAuthority: args.updateAuthority.address,
       mint: args.mint.address,


### PR DESCRIPTION
### Problem

a type issue previously existed on the token22 package that required a `ts-ignore` comment. this is no longer required

### Summary of Changes

removed 2 `ts-ignore` comments