### PR TITLE
Fix Default Decimals Logic to Respect Zero Value

### DIFF
--- a/packages/gill/src/programs/token/instructions/create-token.ts
+++ b/packages/gill/src/programs/token/instructions/create-token.ts
@@ -79,7 +79,7 @@ export function getCreateTokenInstructions(args: GetCreateTokenInstructionsArgs)
   args.tokenProgram = checkedTokenProgramAddress(args.tokenProgram);
   args.feePayer = checkedTransactionSigner(args.feePayer);
 
-  if (!args.decimals) args.decimals = 9;
+  if (args.decimals == null) args.decimals = 9;
   if (!args.mintAuthority) args.mintAuthority = args.feePayer;
   if (!args.updateAuthority) args.updateAuthority = args.feePayer;
   if (args.freezeAuthority) args.freezeAuthority = checkedAddress(args.freezeAuthority);


### PR DESCRIPTION
### Problem

The `getCreateTokenInstructions` function does not respect when `decimals` is `0` and will use the default value of `9`

### Summary of Changes

Check if `args.decimals == null` as this will match both `null` and `undefined` but not zero

Fixes #112 