### PR TITLE
test: test the 0 decimals in `getCreateTokenInstructions`

### DIFF
--- a/.changeset/honest-kangaroos-glow.md
+++ b/.changeset/honest-kangaroos-glow.md
@@ -1,0 +1,7 @@
+---
+"gill": patch
+---
+
+fix (and test for) creating tokens using custom `decimals` input
+
+note: the fix was added in [PR #113](https://github.com/solana-foundation/gill/pull/113) by [@0xIchigo](https://github.com/0xIchigo)

--- a/packages/gill/src/__tests__/create-token-instructions.ts
+++ b/packages/gill/src/__tests__/create-token-instructions.ts
@@ -231,6 +231,28 @@ describe("getCreateTokenInstructions", () => {
       );
     });
 
+    it("should allow custom decimals of 0 when provided, not the default of 9", () => {
+      const args: GetCreateTokenInstructionsArgs = {
+        feePayer: mockPayer,
+        metadataAddress: mockMetadataAddress,
+        mint: mockMint,
+        decimals: 0,
+        metadata,
+      };
+
+      getCreateTokenInstructions(args);
+
+      expect(getInitializeMintInstruction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mint: mockMint.address,
+          decimals: 0,
+        }),
+        {
+          programAddress: TOKEN_PROGRAM_ADDRESS,
+        },
+      );
+    });
+
     it("should use custom mint and freeze authorities when provided", () => {
       const args: GetCreateTokenInstructionsArgs = {
         feePayer: mockPayer,


### PR DESCRIPTION
### Problem

There is no test to ensure `decimals=0` will be correctly used when calling `getCreateTokenInstructions`

### Summary of Changes

added a test 