### PR TITLE
[feat] add reference keys

### DIFF
--- a/.changeset/wicked-nails-clap.md
+++ b/.changeset/wicked-nails-clap.md
@@ -1,0 +1,6 @@
+---
+"gill": minor
+---
+
+added `insertReferenceKeysToTransactionMessage` and `insertReferenceKeyToTransactionMessage` functions to insert
+reference keys into transactions

--- a/examples/get-started/README.md
+++ b/examples/get-started/README.md
@@ -6,8 +6,8 @@ offering the low level "escape hatches" when developers need (or want)
 fine-grain control.
 
 Take a look through these examples to see how gill works and even
-[how it compares](#comparison-of-gill-vs-solanakit-aka-web3js-v2) to using the vanilla web3js
-v2 library.
+[how it compares](#comparison-of-gill-vs-solanakit-aka-web3js-v2) to using the
+vanilla web3js v2 library.
 
 ## Tech stack used
 
@@ -46,6 +46,7 @@ files (in order):
 - [`intro.ts`](./src/intro.ts)
 - [`airdrop.ts`](./src/airdrop.ts)
 - [`tokens.ts`](./src/tokens.ts)
+- [`reference-keys.ts`](./src/reference-keys.ts)
 
 #### `intro.ts`
 
@@ -87,6 +88,17 @@ wallet:
 
 > For more examples interacting with Tokens on Solana, see the
 > [token examples examples here](../tokens/README.md)
+
+### `reference-keys.ts`
+
+This script demonstrates the process to add a reference key into a transaction.
+
+Adding reference keys to transactions allows developers to be able track the
+completion of transactions given to users, without knowing the signature ahead
+of time. Then, perform any desired logic after detection of the reference keyed
+transaction landing onchain.
+
+Most notably utilized within SolanaPay and Blinks.
 
 ## Comparison of gill vs @solana/kit (aka web3js v2)
 

--- a/examples/get-started/src/reference-keys.ts
+++ b/examples/get-started/src/reference-keys.ts
@@ -1,0 +1,93 @@
+/**
+ * This script demonstrates the process to add a reference key into a transaction.
+ *
+ * Adding reference keys to transactions allows developers to be able track the completion
+ * of transactions given to users, without knowing the signature ahead of time. Then, perform
+ * any desired logic after detection of the reference keyed transaction landing onchain.
+ *
+ * Most notably utilized within SolanaPay and Blinks.
+ */
+import {
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getOldestSignatureForAddress,
+  getSignatureFromTransaction,
+  insertReferenceKeysToTransactionMessage,
+  pipe,
+  signTransactionMessageWithSigners,
+} from "gill";
+import { loadKeypairSignerFromFile } from "gill/node";
+import { getAddMemoInstruction } from "gill/programs";
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const { address: reference } = await generateKeyPairSigner();
+
+console.warn("[reference key]");
+console.log(reference);
+
+const signer = await loadKeypairSignerFromFile();
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+/**
+ * !NOTICE!
+ *
+ * Inserting reference keys to transactions (aka attaching addresses to instructions)
+ * involves
+ *
+ * The SPL Memo program (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`) does NOT allow
+ * accounts added to its instructions unless they are actually signing the transaction.
+ * Even if the address is marked as a "non-signer" on the instruction.
+ *
+ * Therefore, transactions must have at least one other instruction other than a Memo
+ * instruction. Adding a single Compute Budget instruction can satisfy this requirement.
+ */
+const tx = pipe(
+  createTransaction({
+    version: "legacy",
+    feePayer: signer,
+    instructions: [
+      getAddMemoInstruction({
+        memo: "gm world!",
+      }),
+    ],
+    latestBlockhash,
+    // setting a CU limit ensures their is at least one non-memo instruction
+    computeUnitLimit: 5000,
+  }),
+  (tx) => insertReferenceKeysToTransactionMessage([reference], tx),
+);
+
+const signedTransaction = await signTransactionMessageWithSigners(tx);
+
+try {
+  const signature = getSignatureFromTransaction(signedTransaction);
+
+  console.log(
+    "Sending transaction:",
+    getExplorerLink({
+      cluster: "devnet",
+      transaction: signature,
+    }),
+  );
+
+  await sendAndConfirmTransaction(signedTransaction);
+
+  console.log("Transaction confirmed!");
+
+  const oldest = await getOldestSignatureForAddress(rpc, reference);
+
+  console.log("oldest signature:", oldest.signature);
+  console.log(
+    "does the oldest signature match the original signature:",
+    oldest.signature === signature,
+  );
+} catch (err) {
+  console.error("Unable to send and confirm the transaction");
+  console.error(err);
+}

--- a/packages/gill/src/__tests__/reference-keys.ts
+++ b/packages/gill/src/__tests__/reference-keys.ts
@@ -1,0 +1,203 @@
+import { AccountRole, Address, BaseTransactionMessage, SolanaError } from "@solana/kit";
+import { insertReferenceKeysToTransactionMessage, insertReferenceKeyToTransactionMessage } from "../core";
+
+// Mock for BaseTransactionMessage
+const createMockTransaction = (instructions: any[]): BaseTransactionMessage => {
+  return Object.freeze({
+    instructions: Object.freeze(instructions),
+    // Add other required properties of BaseTransactionMessage interface if needed
+  }) as unknown as BaseTransactionMessage;
+};
+
+describe("insertReferenceKeyToTransactionMessage", () => {
+  const referenceKey = "someReferenceAddress" as Address;
+
+  const memoInstruction = {
+    programAddress: "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" as Address,
+    accounts: [],
+  };
+
+  it("should insert a single reference key into transaction message", () => {
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([nonMemoInstruction]);
+
+    const result = insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+
+    expect(result).not.toBe(transaction); // Should return a new object (immutability)
+    expect(result.instructions.length).toBe(1);
+    expect(result.instructions[0].accounts).toHaveLength(2);
+    expect(result.instructions[0].accounts?.[1]).toEqual({
+      address: referenceKey,
+      role: AccountRole.READONLY,
+    });
+  });
+
+  it("should throw an error if transaction has no instructions", () => {
+    const transaction = createMockTransaction([]);
+
+    expect(() => {
+      insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+    }).toThrow(SolanaError);
+  });
+
+  it("should throw an error if transaction has only memo instructions", () => {
+    const transaction = createMockTransaction([memoInstruction]);
+
+    expect(() => {
+      insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+    }).toThrow(SolanaError);
+  });
+
+  it("should modify the first non-memo instruction when when memo is first", () => {
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([memoInstruction, nonMemoInstruction]);
+
+    const result = insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+
+    expect(result.instructions.length).toBe(2);
+    expect(result.instructions[0]).toEqual(memoInstruction); // First instruction unchanged
+    expect(result.instructions[1].accounts).toHaveLength(2);
+    expect(result.instructions[1].accounts?.[1]).toEqual({
+      address: referenceKey,
+      role: AccountRole.READONLY,
+    });
+  });
+
+  it("should modify the first non-memo instruction when when memo is NOT first", () => {
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([nonMemoInstruction, memoInstruction]);
+
+    const result = insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+
+    expect(result.instructions.length).toBe(2);
+    expect(result.instructions[1]).toEqual(memoInstruction); // First instruction unchanged
+    expect(result.instructions[0].accounts).toHaveLength(2);
+    expect(result.instructions[0].accounts?.[1]).toEqual({
+      address: referenceKey,
+      role: AccountRole.READONLY,
+    });
+  });
+
+  it("should handle instructions without existing accounts array", () => {
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      // No accounts array
+    };
+    const transaction = createMockTransaction([nonMemoInstruction]);
+
+    const result = insertReferenceKeyToTransactionMessage(referenceKey, transaction);
+
+    expect(result.instructions[0].accounts).toHaveLength(1);
+    expect(result.instructions[0].accounts?.[0]).toEqual({
+      address: referenceKey,
+      role: AccountRole.READONLY,
+    });
+  });
+});
+
+describe("insertReferenceKeysToTransactionMessage", () => {
+  it("should insert multiple reference keys into transaction message", () => {
+    const referenceKeys = [
+      "referenceAddress1" as Address,
+      "referenceAddress2" as Address,
+      "referenceAddress3" as Address,
+    ];
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([nonMemoInstruction]);
+
+    const result = insertReferenceKeysToTransactionMessage(referenceKeys, transaction);
+
+    expect(result.instructions[0].accounts).toHaveLength(4); // 1 original + 3 references
+
+    expect(result.instructions[0].accounts?.[1]).toEqual({
+      address: referenceKeys[0],
+      role: AccountRole.READONLY,
+    });
+    expect(result.instructions[0].accounts?.[2]).toEqual({
+      address: referenceKeys[1],
+      role: AccountRole.READONLY,
+    });
+    expect(result.instructions[0].accounts?.[3]).toEqual({
+      address: referenceKeys[2],
+      role: AccountRole.READONLY,
+    });
+  });
+
+  it("should handle empty reference keys array", () => {
+    const referenceKeys: Address[] = [];
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([nonMemoInstruction]);
+
+    const result = insertReferenceKeysToTransactionMessage(referenceKeys, transaction);
+
+    expect(result.instructions[0].accounts).toHaveLength(1); // No changes to accounts
+    expect(result).not.toBe(transaction); // Still returns a new object
+  });
+
+  it("should throw an error if transaction has no instructions", () => {
+    const referenceKeys = ["someReferenceAddress" as Address];
+    const transaction = createMockTransaction([]);
+
+    expect(() => {
+      insertReferenceKeysToTransactionMessage(referenceKeys, transaction);
+    }).toThrow(SolanaError);
+  });
+
+  it("should preserve transaction immutability", () => {
+    const referenceKeys = ["referenceAddress1" as Address];
+    const originalInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [{ address: "account1" as Address, role: AccountRole.READONLY }],
+    };
+    const transaction = createMockTransaction([originalInstruction]);
+    const originalInstructionsLength = transaction.instructions.length;
+    const originalAccountsLength = transaction.instructions[0].accounts?.length || 0;
+
+    const result = insertReferenceKeysToTransactionMessage(referenceKeys, transaction);
+
+    expect(transaction.instructions.length).toBe(originalInstructionsLength);
+    expect(transaction.instructions[0].accounts?.length).toBe(originalAccountsLength);
+    expect(result.instructions[0].accounts?.length).toBe(originalAccountsLength + 1);
+  });
+
+  it("should handle instruction with different account roles", () => {
+    const referenceKeys = ["referenceAddress1" as Address];
+    const nonMemoInstruction = {
+      programAddress: "SomeProgram",
+      accounts: [
+        { address: "account1" as Address, role: AccountRole.READONLY },
+        { address: "account2" as Address, role: AccountRole.WRITABLE },
+        { address: "account3" as Address, role: AccountRole.READONLY_SIGNER },
+        { address: "account4" as Address, role: AccountRole.WRITABLE_SIGNER },
+      ],
+    };
+    const transaction = createMockTransaction([nonMemoInstruction]);
+
+    const result = insertReferenceKeysToTransactionMessage(referenceKeys, transaction);
+
+    expect(result.instructions[0].accounts).toHaveLength(5);
+    // Original accounts are preserved with their roles
+    expect(result.instructions[0].accounts?.[0].role).toBe(AccountRole.READONLY);
+    expect(result.instructions[0].accounts?.[1].role).toBe(AccountRole.WRITABLE);
+    expect(result.instructions[0].accounts?.[2].role).toBe(AccountRole.READONLY_SIGNER);
+    expect(result.instructions[0].accounts?.[3].role).toBe(AccountRole.WRITABLE_SIGNER);
+    // New reference is added with READONLY role
+    expect(result.instructions[0].accounts?.[4].address).toBe(referenceKeys[0]);
+    expect(result.instructions[0].accounts?.[4].role).toBe(AccountRole.READONLY);
+  });
+});

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -15,3 +15,4 @@ export * from "./base64-to-transaction";
 export * from "./base64-from-transaction";
 export * from "./simulate-transaction";
 export * from "./get-oldest-signature";
+export * from "./insert-reference-key";

--- a/packages/gill/src/core/insert-reference-key.ts
+++ b/packages/gill/src/core/insert-reference-key.ts
@@ -1,0 +1,60 @@
+import type { Address, BaseTransactionMessage } from "@solana/kit";
+import { AccountRole, SOLANA_ERROR__INSTRUCTION_ERROR__GENERIC_ERROR, SolanaError } from "@solana/kit";
+import type { getOldestSignatureForAddress } from "./get-oldest-signature";
+
+/**
+ * Insert a single of reference key {@link Address} into a transaction message
+ *
+ * Use {@link getOldestSignatureForAddress} to locate the oldest signature for a reference key's address
+ *
+ * Note: The `transaction` must have at least one non-memo instruction.
+ */
+export function insertReferenceKeyToTransactionMessage<TTransaction extends BaseTransactionMessage>(
+  reference: Address,
+  transaction: TTransaction,
+): TTransaction {
+  return insertReferenceKeysToTransactionMessage([reference], transaction);
+}
+
+/**
+ * Insert multiple reference key {@link Address | Addresses} into a transaction message
+ *
+ * Use {@link getOldestSignatureForAddress} to locate the oldest signature for a reference key's address
+ *
+ * Note: The `transaction` must have at least one non-memo instruction.
+ */
+export function insertReferenceKeysToTransactionMessage<TTransaction extends BaseTransactionMessage>(
+  references: Address[],
+  transaction: TTransaction,
+): TTransaction {
+  const nonMemoIndex = transaction.instructions.findIndex(
+    (ix) => ix.programAddress !== "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  );
+
+  if (transaction.instructions.length == 0 || nonMemoIndex == -1) {
+    throw new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__GENERIC_ERROR, {
+      index: transaction.instructions.length || nonMemoIndex,
+      cause: "At least one non-memo instruction is required",
+    });
+  }
+
+  const modifiedIx = {
+    ...transaction.instructions[nonMemoIndex],
+    accounts: [
+      ...(transaction.instructions[nonMemoIndex].accounts || []),
+      // actually insert the reference keys
+      ...references.map((ref) => ({
+        address: ref,
+        role: AccountRole.READONLY,
+      })),
+    ],
+  };
+
+  const instructions = [...transaction.instructions];
+  instructions.splice(nonMemoIndex, 1, modifiedIx);
+
+  return Object.freeze({
+    ...transaction,
+    instructions: Object.freeze(instructions),
+  });
+}


### PR DESCRIPTION
### Problem

It is cumbersome to manually insert reference keys into transactions, which is a common practice used by the Solana Pay and Blink spec

### Summary of Changes

add helper functions to insert reference keys into transactions