### PR TITLE
fix: manually declare declarations

### DIFF
--- a/.changeset/thirty-cycles-play.md
+++ b/.changeset/thirty-cycles-play.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+manually add to declarations

--- a/packages/gill/tsconfig.declarations.json
+++ b/packages/gill/tsconfig.declarations.json
@@ -1,10 +1,10 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "extends": "./tsconfig.json",
-  "include": ["src/index.ts", "src/types"]
+  "include": ["src/programs/token/index.ts", "src/programs/index.ts", "src/node/index.ts", "src/index.ts", "src/types"]
 }

--- a/packages/gill/tsconfig.json
+++ b/packages/gill/tsconfig.json
@@ -2,5 +2,5 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "gill",
   "extends": "../tsconfig/base.json",
-  "include": ["src"]
+  "include": ["src", "src/programs/token/index.ts", "src/programs/index.ts", "src/node/index.ts", "src/types"]
 }


### PR DESCRIPTION
### Problem

it appears as if gill subpath types are not always being generated

### Summary of Changes

manually add them to the tsconfig includes