### PR TITLE
refactor: rename mint args

### DIFF
--- a/.changeset/friendly-chefs-serve.md
+++ b/.changeset/friendly-chefs-serve.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+rename token metadata mint args and fixed type reexports

--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -56,7 +56,7 @@ jobs:
             xargs -t0 -n 1 -I {} \
               sh -c 'cd {} && pnpm pkg delete devDependencies'
           pnpm changeset version --snapshot canary
-          pnpm changeset publish --tag canary
+          pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -62,3 +62,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_TAG: canary
+
+      - name: Remove canary label from PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'canary'
+            });

--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [opened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -27,6 +29,11 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
+    # Only run if it's a push to master, manual dispatch, or PR with 'canary' label
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'canary'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -56,7 +56,7 @@ jobs:
             xargs -t0 -n 1 -I {} \
               sh -c 'cd {} && pnpm pkg delete devDependencies'
           pnpm changeset version --snapshot canary
-          pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
+          pnpm changeset publish --tag canary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/e2e/imports/package.json
+++ b/e2e/imports/package.json
@@ -2,6 +2,7 @@
   "name": "gill-e2e",
   "license": "MIT",
   "private": true,
+  "type": "module",
   "version": "0.1.0",
   "scripts": {
     "test:unit:node": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} pnpm start:tsx && pnpm start:node",

--- a/e2e/imports/src/imports.js
+++ b/e2e/imports/src/imports.js
@@ -6,64 +6,64 @@
  * SPL System program client
  */
 import { SYSTEM_PROGRAM_ADDRESS } from "gill/programs";
-console.log(SYSTEM_PROGRAM_ADDRESS);
+SYSTEM_PROGRAM_ADDRESS;
 
 import { getTransferSolInstruction } from "gill/programs";
-console.log(getTransferSolInstruction);
+getTransferSolInstruction;
 
 /**
  * SPL Address Lookup Table program client
  */
 import { ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS } from "gill/programs";
-console.log(ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS);
+ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS;
 
 import { getAddressLookupTableDecoder } from "gill/programs";
-console.log(getAddressLookupTableDecoder);
+getAddressLookupTableDecoder;
 
 /**
  * SPL Compute Budget program client
  */
 import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from "gill/programs";
-console.log(COMPUTE_BUDGET_PROGRAM_ADDRESS);
+COMPUTE_BUDGET_PROGRAM_ADDRESS;
 
 import { getSetComputeUnitLimitInstruction } from "gill/programs";
-console.log(getSetComputeUnitLimitInstruction);
+getSetComputeUnitLimitInstruction;
 
 // !this is a custom symbol that gill provides
 import { isSetComputeLimitInstruction } from "gill/programs";
-console.log(isSetComputeLimitInstruction);
+isSetComputeLimitInstruction;
 
 /**
  * !SPL Memo program is generated and vendored in
  */
 import { MEMO_PROGRAM_ADDRESS } from "gill/programs";
-console.log(MEMO_PROGRAM_ADDRESS);
+MEMO_PROGRAM_ADDRESS;
 
 import { getAddMemoInstruction } from "gill/programs";
-console.log(getAddMemoInstruction);
+getAddMemoInstruction;
 
 /**
  * ! Metaplex's Token Metadata client is generated and vendored in
  */
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "gill/programs";
-console.log(TOKEN_METADATA_PROGRAM_ADDRESS);
+TOKEN_METADATA_PROGRAM_ADDRESS;
 
 import { getMetadataCodec } from "gill/programs";
-console.log(getMetadataCodec);
+getMetadataCodec;
 
 /**
  * SPL Token 2022 program client
  */
 import { TOKEN_2022_PROGRAM_ADDRESS } from "gill/programs/token";
-console.log(TOKEN_2022_PROGRAM_ADDRESS);
+TOKEN_2022_PROGRAM_ADDRESS;
 
 import { getMintToInstruction } from "gill/programs/token";
-console.log(getMintToInstruction);
+getMintToInstruction;
 
 // !this is a custom symbol that gill provides
 import { getAssociatedTokenAccountAddress } from "gill/programs/token";
-console.log(getAssociatedTokenAccountAddress);
+getAssociatedTokenAccountAddress;
 
 // !this is a custom symbol that gill provides
 import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
-console.log(TOKEN_PROGRAM_ADDRESS);
+TOKEN_PROGRAM_ADDRESS;

--- a/e2e/imports/src/imports.ts
+++ b/e2e/imports/src/imports.ts
@@ -6,64 +6,83 @@
  * SPL System program client
  */
 import { SYSTEM_PROGRAM_ADDRESS } from "gill/programs";
-console.log(SYSTEM_PROGRAM_ADDRESS);
+SYSTEM_PROGRAM_ADDRESS;
+
+import type { ParsedSystemInstruction } from "gill/programs";
+null as unknown as ParsedSystemInstruction;
 
 import { getTransferSolInstruction } from "gill/programs";
-console.log(getTransferSolInstruction);
+getTransferSolInstruction;
 
 /**
  * SPL Address Lookup Table program client
  */
 import { ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS } from "gill/programs";
-console.log(ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS);
+ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS;
+
+import type { ParsedAddressLookupTableInstruction } from "gill/programs";
+null as unknown as ParsedAddressLookupTableInstruction;
 
 import { getAddressLookupTableDecoder } from "gill/programs";
-console.log(getAddressLookupTableDecoder);
+getAddressLookupTableDecoder;
 
 /**
  * SPL Compute Budget program client
  */
 import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from "gill/programs";
-console.log(COMPUTE_BUDGET_PROGRAM_ADDRESS);
+COMPUTE_BUDGET_PROGRAM_ADDRESS;
+
+import type { ParsedComputeBudgetInstruction } from "gill/programs";
+null as unknown as ParsedComputeBudgetInstruction;
 
 import { getSetComputeUnitLimitInstruction } from "gill/programs";
-console.log(getSetComputeUnitLimitInstruction);
+getSetComputeUnitLimitInstruction;
 
 // !this is a custom symbol that gill provides
 import { isSetComputeLimitInstruction } from "gill/programs";
-console.log(isSetComputeLimitInstruction);
+isSetComputeLimitInstruction;
 
 /**
  * !SPL Memo program is generated and vendored in
  */
 import { MEMO_PROGRAM_ADDRESS } from "gill/programs";
-console.log(MEMO_PROGRAM_ADDRESS);
+MEMO_PROGRAM_ADDRESS;
+
+// see Token Metadata's `MAINTAINERS.md` file about this type being renamed from `MintArgs` to `MetadataMintArgs`
+import type { MetadataMintArgs } from "gill/programs";
+null as unknown as MetadataMintArgs;
 
 import { getAddMemoInstruction } from "gill/programs";
-console.log(getAddMemoInstruction);
+getAddMemoInstruction;
 
 /**
  * ! Metaplex's Token Metadata client is generated and vendored in
  */
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "gill/programs";
-console.log(TOKEN_METADATA_PROGRAM_ADDRESS);
+TOKEN_METADATA_PROGRAM_ADDRESS;
+
+import type { ParsedMemoInstruction } from "gill/programs";
+null as unknown as ParsedMemoInstruction;
 
 import { getMetadataCodec } from "gill/programs";
-console.log(getMetadataCodec);
+getMetadataCodec;
 
 /**
  * SPL Token 2022 program client
  */
 import { TOKEN_2022_PROGRAM_ADDRESS } from "gill/programs/token";
-console.log(TOKEN_2022_PROGRAM_ADDRESS);
+TOKEN_2022_PROGRAM_ADDRESS;
 
 import { getMintToInstruction } from "gill/programs/token";
-console.log(getMintToInstruction);
+getMintToInstruction;
+
+import type { ParsedToken2022Instruction } from "gill/programs/token";
+null as unknown as ParsedToken2022Instruction;
 
 // !this is a custom symbol that gill provides
 import { getAssociatedTokenAccountAddress } from "gill/programs/token";
-console.log(getAssociatedTokenAccountAddress);
+getAssociatedTokenAccountAddress;
 
 // !this is a custom symbol that gill provides
 import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
-console.log(TOKEN_PROGRAM_ADDRESS);
+TOKEN_PROGRAM_ADDRESS;

--- a/packages/gill/generate-reexports.ts
+++ b/packages/gill/generate-reexports.ts
@@ -34,6 +34,7 @@ async function generateExports() {
         exports += `export {\n`;
         exports += exportNames.map((name) => `  ${name},`).join("\n");
         exports += `\n} from "${pkg.package}";\n\n`;
+        exports += `export type * from "${pkg.package}";\n`;
       }
 
       // Write to output file

--- a/packages/gill/src/programs/system/reexports.ts
+++ b/packages/gill/src/programs/system/reexports.ts
@@ -125,3 +125,4 @@ export {
   parseWithdrawNonceAccountInstruction,
 } from "@solana-program/system";
 
+export type * from "@solana-program/system";

--- a/packages/gill/src/programs/token-metadata/MAINTAINERS.md
+++ b/packages/gill/src/programs/token-metadata/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Token Metadata program client
+
+The included Token Metadata program client was generated using [Codama](https://github.com/codama-idl/codama).
+
+## Naming collisions
+
+There is a naming collision between the Token Metadata program and the SPL Token/Token22 program clients for the
+`MintArgs` type.
+
+Since gill ships a generated client for Token Metadata, and reexports the Token22 client from its source package, the
+Token Metadata's `MintArgs` were renamed to `MetadataMintArgs`.
+
+See [./generated/types/mintArgs.ts](./generated/types/mintArgs.ts)

--- a/packages/gill/src/programs/token-metadata/generated/types/mintArgs.ts
+++ b/packages/gill/src/programs/token-metadata/generated/types/mintArgs.ts
@@ -23,22 +23,22 @@ import {
   type GetDiscriminatedUnionVariantContent,
   type Option,
   type OptionOrNullable,
-} from '@solana/kit';
+} from "@solana/kit";
 import {
   getAuthorizationDataDecoder,
   getAuthorizationDataEncoder,
   type AuthorizationData,
   type AuthorizationDataArgs,
-} from '.';
+} from ".";
 
-export type MintArgs = {
-  __kind: 'V1';
+export type MetadataMintArgs = {
+  __kind: "V1";
   amount: bigint;
   authorizationData: Option<AuthorizationData>;
 };
 
 export type MintArgsArgs = {
-  __kind: 'V1';
+  __kind: "V1";
   amount: number | bigint;
   authorizationData: OptionOrNullable<AuthorizationDataArgs>;
 };
@@ -46,48 +46,43 @@ export type MintArgsArgs = {
 export function getMintArgsEncoder(): Encoder<MintArgsArgs> {
   return getDiscriminatedUnionEncoder([
     [
-      'V1',
+      "V1",
       getStructEncoder([
-        ['amount', getU64Encoder()],
-        ['authorizationData', getOptionEncoder(getAuthorizationDataEncoder())],
+        ["amount", getU64Encoder()],
+        ["authorizationData", getOptionEncoder(getAuthorizationDataEncoder())],
       ]),
     ],
   ]);
 }
 
-export function getMintArgsDecoder(): Decoder<MintArgs> {
+export function getMintArgsDecoder(): Decoder<MetadataMintArgs> {
   return getDiscriminatedUnionDecoder([
     [
-      'V1',
+      "V1",
       getStructDecoder([
-        ['amount', getU64Decoder()],
-        ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
+        ["amount", getU64Decoder()],
+        ["authorizationData", getOptionDecoder(getAuthorizationDataDecoder())],
       ]),
     ],
   ]);
 }
 
-export function getMintArgsCodec(): Codec<MintArgsArgs, MintArgs> {
+export function getMintArgsCodec(): Codec<MintArgsArgs, MetadataMintArgs> {
   return combineCodec(getMintArgsEncoder(), getMintArgsDecoder());
 }
 
 // Data Enum Helpers.
 export function mintArgs(
-  kind: 'V1',
-  data: GetDiscriminatedUnionVariantContent<MintArgsArgs, '__kind', 'V1'>
-): GetDiscriminatedUnionVariant<MintArgsArgs, '__kind', 'V1'>;
-export function mintArgs<K extends MintArgsArgs['__kind'], Data>(
-  kind: K,
-  data?: Data
-) {
-  return Array.isArray(data)
-    ? { __kind: kind, fields: data }
-    : { __kind: kind, ...(data ?? {}) };
+  kind: "V1",
+  data: GetDiscriminatedUnionVariantContent<MintArgsArgs, "__kind", "V1">,
+): GetDiscriminatedUnionVariant<MintArgsArgs, "__kind", "V1">;
+export function mintArgs<K extends MintArgsArgs["__kind"], Data>(kind: K, data?: Data) {
+  return Array.isArray(data) ? { __kind: kind, fields: data } : { __kind: kind, ...(data ?? {}) };
 }
 
-export function isMintArgs<K extends MintArgs['__kind']>(
+export function isMintArgs<K extends MetadataMintArgs["__kind"]>(
   kind: K,
-  value: MintArgs
-): value is MintArgs & { __kind: K } {
+  value: MetadataMintArgs,
+): value is MetadataMintArgs & { __kind: K } {
   return value.__kind === kind;
 }


### PR DESCRIPTION

### Summary of Changes

- canary publishing to only happy on canary tag, which now gets auto removed after canary is published
- renamed token metadata's `MintArgs` to `MetadataMintArgs` and documented in the maintainers.md file (which was also added)
- improved the reexport script to include types