### PR TITLE
chore: manual version

### DIFF
--- a/.changeset/fair-carrots-brake.md
+++ b/.changeset/fair-carrots-brake.md
@@ -1,0 +1,6 @@
+---
+"gill": patch
+---
+
+manually fix gill version to deprecate the broken gill@0.10.0 version
+see https://github.com/solana-foundation/gill/pull/140

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gill",
   "license": "MIT",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "a modern javascript/typescript client library for interacting with the Solana blockchain",
   "scripts": {
     "clean": "rimraf dist build node_modules .turbo .docs",


### PR DESCRIPTION
### Problem

gill@0.10.0 broke program client imports and required a revert and new patch published. see https://github.com/solana-foundation/gill/pull/140

### Summary of Changes

manually bump the gill version to continue publishing on 0.10.x

Fixes #139 