### PR TITLE
fix: no canary on master

### DIFF
--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - master
   pull_request:
     types: [opened, synchronize, labeled]
 


### PR DESCRIPTION
### Problem

the canary publishing is incorrectly attempting to run after merging to the master branch

### Summary of Changes

prevent this. canary publishing should only be available on PRs