### PR TITLE
feat: add create-codama-config function

### DIFF
--- a/.changeset/giant-lobsters-hope.md
+++ b/.changeset/giant-lobsters-hope.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+add create-codama-config function

--- a/packages/gill/src/__tests__/create-codama.config.ts
+++ b/packages/gill/src/__tests__/create-codama.config.ts
@@ -1,0 +1,41 @@
+import { createCodamaConfig } from "../core";
+
+describe("createCodamaConfig", () => {
+  it("should return a valid config object", () => {
+    const clientJs = "anchor/src/client/js";
+    const idl = "anchor/target/idl/counter.json";
+
+    const config = createCodamaConfig({
+      clientJs,
+      idl,
+    });
+
+    expect(config).toMatchObject({
+      idl,
+      scripts: {
+        js: {
+          args: [
+            clientJs,
+            {
+              dependencyMap: {
+                solanaAccounts: "gill",
+                solanaAddresses: "gill",
+                solanaCodecsCore: "gill",
+                solanaCodecsDataStructures: "gill",
+                solanaCodecsNumbers: "gill",
+                solanaCodecsStrings: "gill",
+                solanaErrors: "gill",
+                solanaInstructions: "gill",
+                solanaOptions: "gill",
+                solanaPrograms: "gill",
+                solanaRpcTypes: "gill",
+                solanaSigners: "gill",
+              },
+            },
+          ],
+          from: "@codama/renderers-js",
+        },
+      },
+    });
+  });
+});

--- a/packages/gill/src/core/create-codama-config.ts
+++ b/packages/gill/src/core/create-codama-config.ts
@@ -1,0 +1,34 @@
+export const GILL_EXTERNAL_MODULE_MAP: Record<string, string> = {
+  solanaAccounts: "gill",
+  solanaAddresses: "gill",
+  solanaCodecsCore: "gill",
+  solanaCodecsDataStructures: "gill",
+  solanaCodecsNumbers: "gill",
+  solanaCodecsStrings: "gill",
+  solanaErrors: "gill",
+  solanaInstructions: "gill",
+  solanaOptions: "gill",
+  solanaPrograms: "gill",
+  solanaRpcTypes: "gill",
+  solanaSigners: "gill",
+};
+
+export function createCodamaConfig({
+  clientJs,
+  dependencyMap = GILL_EXTERNAL_MODULE_MAP,
+  idl,
+}: {
+  clientJs: string;
+  dependencyMap?: Record<string, string>;
+  idl: string;
+}) {
+  return {
+    idl,
+    scripts: {
+      js: {
+        args: [clientJs, { dependencyMap }],
+        from: "@codama/renderers-js",
+      },
+    },
+  };
+}

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -16,3 +16,4 @@ export * from "./base64-from-transaction";
 export * from "./simulate-transaction";
 export * from "./get-oldest-signature";
 export * from "./insert-reference-key";
+export * from "./create-codama-config";


### PR DESCRIPTION
### Problem

Configuring [codama to work with gill](https://gill.site/docs/guides/codama) can by optimized if we use the `codama.js` instead of the json file with a helper function.


### Summary of Changes
This PR implements the `createCodamaConfig` function.


```js
// codama.js
import { createCodamaConfig } from 'gill'

export default createCodamaConfig({
  clientJs: 'anchor/src/client/js',
  idl: 'anchor/target/idl/counter.json',
})

```