### PR TITLE
fix: docs for multiple package manager in codama

### DIFF
--- a/docs/content/docs/guides/codama.mdx
+++ b/docs/content/docs/guides/codama.mdx
@@ -33,8 +33,8 @@ Solana program your IDL is from.
 To get started, you first need to install the
 [Codama CLI](https://github.com/codama-idl/codama/tree/main/packages/cli) inside your repo:
 
-```shell
-pnpm install @codama/cli
+```package-install
+@codama/cli
 ```
 
 <Callout type="warn">
@@ -46,7 +46,7 @@ pnpm install @codama/cli
 This will allow you to execute the Codama CLI via your package manager's "run" command:
 
 ```shell
-pnpm codama --version
+npx codama --version
 # output: 1.1.1
 ```
 
@@ -98,7 +98,7 @@ With your Codama config file setup, you can use the `run` command to generate yo
 JavaScript/TypeScript client, storing the generated output in your configured destination:
 
 ```shell
-pnpm codama run js
+npx codama run js
 ```
 
 You can now import your newly generated client library from anywhere in your code base or publish as
@@ -124,11 +124,11 @@ For example, the gill library itself utilizes a shell script similar to this one
 set -euo pipefail
 
 # generate all the codama clients (per their respective config files)
-pnpm codama run js --config ./idls/token_metadata/codama.js
-pnpm codama run js --config ./idls/another_program/codama.js
+npx codama run js --config ./idls/token_metadata/codama.js
+npx codama run js --config ./idls/another_program/codama.js
 
 # run the repo's prettier settings on the generated files
-pnpm prettier --write './packages/gill/src/programs/**/generated/{*,**/*}.{ts,js}'
+npx prettier --write './packages/gill/src/programs/**/generated/{*,**/*}.{ts,js}'
 ```
 
 This script will execute the `codama run js` command for each program by explicitly passing in the
@@ -154,7 +154,7 @@ case, use the `codama.json` file and manually configure it to your needs.
 Run the Codama `init` command and follow the prompts to scaffold your `codama.json` config file:
 
 ```shell
-pnpm codama init
+npx codama init
 ```
 
 You will be asked a few questions in order to generate the config file for your IDL:


### PR DESCRIPTION
### Problem

Currently Codama docs in Gill show only pnpm


### Summary of Changes

adds other package managers or npx as the default for neutrality


Fixes #